### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/sameeralam3127/ipmg/security/code-scanning/1](https://github.com/sameeralam3127/ipmg/security/code-scanning/1)

In general, the fix is to explicitly specify a `permissions:` block for the workflow or for the specific job so that the automatically provided `GITHUB_TOKEN` has only the minimal required scopes. Since this workflow only checks out code and publishes to PyPI using a secret token, it can safely restrict permissions to read-only repository contents.

The best fix here, without changing existing functionality, is to add a `permissions:` block at the workflow root level (applies to all jobs) just after the `on:` section, with `contents: read`. This mirrors CodeQL’s suggested minimal configuration and still allows `actions/checkout` to function correctly, while removing unnecessary write permissions. No additional imports, methods, or definitions are required; this is a pure YAML configuration change confined to `.github/workflows/publish.yml`, near the top of the file.

Concretely:
- Edit `.github/workflows/publish.yml`.
- Insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block (i.e., after line 5 and before line 7). No other lines or steps need modification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
