### PR TITLE
feat: add CLI version flag and release docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Verify installation:
 
 ```bash
 ipmg --help
+ipmg --version
 ```
 
 You can always check the current published version on [PyPI](https://pypi.org/project/ipmg/).
@@ -87,6 +88,7 @@ Test:
 
 ```bash
 ipmg --help
+ipmg --version
 ```
 
 ---
@@ -103,6 +105,7 @@ Verify:
 
 ```bash
 ipmg --help
+ipmg --version
 ```
 
 ---
@@ -122,6 +125,7 @@ Verify:
 
 ```bash
 ipmg --help
+ipmg --version
 ```
 
 ---
@@ -239,6 +243,28 @@ Check that:
 ### **One host crashes the scan**
 
 IPMG now records unexpected per-host failures as `Error` and continues scanning the remaining targets.
+
+---
+
+# Development and Release
+
+Set up a local development environment:
+
+```bash
+python -m pip install --upgrade pip
+pip install -e ".[dev]"
+```
+
+Run the test suite and build the package before opening a release PR:
+
+```bash
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q
+python -m build
+```
+
+Releases are managed from the `main` branch by GitHub Actions. After a PR with a conventional commit such as `feat: ...` or `fix: ...` is merged, the publish workflow runs tests, creates the semantic-release version tag, builds source/wheel distributions, attaches release assets, and publishes the package to [PyPI](https://pypi.org/project/ipmg/) using the `pypi` trusted publishing environment.
+
+Use `ipmg --version` after installation to confirm the installed package version matches the latest PyPI release.
 
 ---
 

--- a/src/ipmg/cli/parser.py
+++ b/src/ipmg/cli/parser.py
@@ -1,8 +1,15 @@
 import argparse
 
+from ipmg import __version__
+
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser("IPMG - IP Management & Ping Monitoring Tool")
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+    )
     parser.add_argument("--input", default="ip_list.xlsx")
     parser.add_argument("--output", default="results")
     parser.add_argument("--timeout", type=int, default=2)

--- a/src/ipmg/infrastructure/file_io.py
+++ b/src/ipmg/infrastructure/file_io.py
@@ -4,10 +4,9 @@ from typing import Iterable
 import pandas as pd
 from rich.panel import Panel
 
-from ipmg.exceptions import FileIOError
 from ipmg.core.ping import validate_ip
+from ipmg.exceptions import FileIOError
 from ipmg.utils.helpers import console, timestamp_str
-
 
 SUPPORTED_INPUT_SUFFIXES = {".xlsx", ".xls", ".csv", ".txt", ".list"}
 MAX_EXPANDED_TARGETS = 65_536

--- a/src/ipmg/services/scan_service.py
+++ b/src/ipmg/services/scan_service.py
@@ -13,9 +13,9 @@ from rich.progress import (
     TimeElapsedColumn,
 )
 
-from ipmg.exceptions import PingError
 from ipmg.core.discovery import discover_local_subnet
 from ipmg.core.ping import ping_ip
+from ipmg.exceptions import PingError
 from ipmg.infrastructure.file_io import (
     create_sample_file,
     load_targets,

--- a/src/ipmg/utils/__init__.py
+++ b/src/ipmg/utils/__init__.py
@@ -1,3 +1,9 @@
-from ipmg.utils.helpers import clamp_int, console, current_timestamp, resolve_hostname, timestamp_str
+from ipmg.utils.helpers import (
+    clamp_int,
+    console,
+    current_timestamp,
+    resolve_hostname,
+    timestamp_str,
+)
 
 __all__ = ["clamp_int", "console", "current_timestamp", "resolve_hostname", "timestamp_str"]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,14 @@
+import pytest
+
+from ipmg import __version__
+from ipmg.cli.parser import build_parser
+
+
+def test_version_flag_prints_package_version(capsys):
+    parser = build_parser()
+
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["--version"])
+
+    assert exc_info.value.code == 0
+    assert capsys.readouterr().out.strip() == f"IPMG - IP Management & Ping Monitoring Tool {__version__}"


### PR DESCRIPTION
## Summary
- add `ipmg --version` using the package version
- document version verification in install flows
- document the test/build/release path for PyPI trusted publishing
- apply ruff import ordering fixes

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` (14 passed)
- `python3 -m ruff check .`
- `PYTHONPATH=src python3 -m ipmg --version`
- `python3 -m build`

After this PR is merged to `main`, the existing Publish workflow should run semantic-release and publish the next release to PyPI if the repository's `pypi` trusted publishing environment is configured correctly.