### PR TITLE
feat: cache reverse DNS lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ ipmg --version
 | Export Results to CSV + XLSX    | `ipmg --formats csv xlsx`           | Exports scan results in CSV and Excel formats.                                |
 | Create a Markdown Report        | `ipmg --formats md csv`             | Saves a readable scan report plus CSV data for tickets, handoffs, and audits. |
 | Resolve Hostnames (PTR Records) | `ipmg --resolve`                    | Performs reverse DNS (PTR) lookups for hostnames.                             |
+| Cache Hostname Lookups          | `ipmg --resolve --dns-cache-ttl 600` | Reuses PTR results for 10 minutes to make repeated scans faster.              |
 | Run Every 10 Minutes            | `ipmg --interval 10`                | Repeats the scan every 10 minutes.                                            |
 
 If the default input file does not exist, IPMG creates a sample file based on the requested extension such as `.xlsx`, `.csv`, or `.txt`.

--- a/README.md
+++ b/README.md
@@ -1,104 +1,47 @@
 # IPMG — IP Management & Ping Monitoring Tool
 
-![PyPI](https://img.shields.io/pypi/v/ipmg)
+[![PyPI](https://img.shields.io/pypi/v/ipmg)](https://pypi.org/project/ipmg/)
 ![Python Version](https://img.shields.io/badge/python-3.8%2B-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
-![Platform](https://img.shields.io/badge/platform-Mac%20%7C%20Linux%20%7C%20Windows-lightgrey)
-![CLI](https://img.shields.io/badge/tool-ipmg-orange)
-![CI Ready](https://img.shields.io/badge/formatting-ruff%20%7C%20black-yellow)
 [![Publish](https://github.com/sameeralam3127/ipmg/actions/workflows/publish.yml/badge.svg)](https://github.com/sameeralam3127/ipmg/actions/workflows/publish.yml)
 
----
+Scan and monitor IP networks from the command line. IPMG pings hosts in
+parallel, resolves hostnames, and exports results as Excel, CSV, JSON, or
+Markdown reports.
 
-**IPMG (IP Management Tool)** is a modern, modular, enterprise-ready network scanner and monitoring utility.
-It replaces the legacy `ip_pinger.py` script with a **clean package architecture**, CLI tooling, and automated workflows.
-
-Designed for:
-
-- Network administrators
-- Systems engineers
-- Cybersecurity teams
-- DevOps and SREs
-
-IPMG supports:
-
-- **Subnet auto-discovery**
-- **Parallel pinging with thread pools**
-- **Hostname resolution**
-- **Multi-format reporting (XLSX/CSV/JSON)**
-- **Human-readable Markdown scan reports**
-- **Flexible target input (XLSX/CSV/text/single IP/CIDR)**
-- **Scheduled recurrent scans**
-- **Auto-generated sample input files**
-- **Colorized CLI output**
-- **Rich console panels, progress bars, and color-coded summaries**
-- **Modular testable architecture**
-- **Batch-level scan timestamps and duration tracking**
+> **Security note:** only scan networks you are authorized to scan.
+> Unauthorized scanning may violate your organization's policies or the law.
 
 ---
 
-## ⚠️ Security Disclaimer
-
-> **Do NOT use this tool on networks without explicit authorization.**
-> Always obtain written approval from your organization's **Cybersecurity / Network Security team**.
-> Unauthorized scanning may violate internal policies or law.
-
-IPMG includes a built-in disclaimer shown at runtime (`security.py`).
-
----
-
-## Features
-
-- Fully modular Python package (`src/ipmg`)
-- System-wide CLI command: `ipmg`
-- Accepts targets from `.xlsx`, `.csv`, `.txt`, `.list`, literal IPs, and CIDR blocks
-- Exports machine-readable files and shareable Markdown reports from the same scan
-- Test coverage via `pytest`
-- Formatting and linting via `ruff` and `black`
-- CI-friendly project structure
-
-> [!NOTE]
-> Modern network utility users usually need both automation-friendly exports and a quick report they can paste into tickets, handoff notes, or incident timelines. IPMG now supports `md` output so one scan can produce spreadsheet data for analysis and a readable operational summary for humans.
-
----
-
-# Installation
-
-## Option 1 — Install from PyPI (recommended for most users)
-
-Install the latest stable release from PyPI:
+## Install
 
 ```bash
 pip install ipmg
 ```
 
-Verify installation:
+Check that it works:
 
 ```bash
-ipmg --help
 ipmg --version
 ```
 
-You can always check the current published version on [PyPI](https://pypi.org/project/ipmg/).
+<details>
+<summary>Other install methods</summary>
 
----
-
-## Option 2 — Install via uv (recommended for isolated global install)
+**uv (isolated global install):**
 
 ```bash
 uv tool install git+https://github.com/sameeralam3127/ipmg.git
 ```
 
-Test:
+**curl installer (installs uv if missing):**
 
 ```bash
-ipmg --help
-ipmg --version
+curl -sSL https://raw.githubusercontent.com/sameeralam3127/ipmg/main/install.sh | bash
 ```
 
----
-
-## Option 3 — Install via pip (editable, development mode)
+**From source (development):**
 
 ```bash
 git clone https://github.com/sameeralam3127/ipmg.git
@@ -106,213 +49,112 @@ cd ipmg
 pip install -e .
 ```
 
-Verify:
+</details>
+
+---
+
+## Quick start
 
 ```bash
-ipmg --help
-ipmg --version
+# Scan your local subnet automatically
+ipmg --discover
+
+# Scan a single host
+ipmg --input 8.8.8.8
+
+# Scan a CIDR range
+ipmg --input 192.168.1.0/24
+
+# Scan targets from a file (xlsx, csv, txt, or list)
+ipmg --input targets.txt
+
+# Resolve hostnames and export CSV + a readable Markdown report
+ipmg --input targets.txt --resolve --formats md csv
 ```
+
+Running plain `ipmg` uses `ip_list.xlsx` as input and creates a sample file
+if it does not exist.
 
 ---
 
-## Option 4 — Install using curl installer
+## Options
 
-```bash
-curl -sSL https://raw.githubusercontent.com/sameeralam3127/ipmg/main/install.sh | bash
-```
-
-This script:
-
-- Installs **uv** if missing
-- Installs **ipmg** globally using uv
-
-Verify:
-
-```bash
-ipmg --help
-ipmg --version
-```
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--input` | `ip_list.xlsx` | Targets: a file (`.xlsx`, `.xls`, `.csv`, `.txt`, `.list`), a single IP, or a CIDR block |
+| `--output` | `results` | Output file name prefix |
+| `--formats` | `xlsx` | One or more of `xlsx`, `csv`, `json`, `md` |
+| `--discover` | off | Auto-detect and scan the local subnet |
+| `--resolve` | off | Reverse DNS (PTR) lookup for each host |
+| `--dns-cache-ttl` | `300` | Cache DNS results for this many seconds (`0` disables caching) |
+| `--timeout` | `2` | Ping timeout in seconds |
+| `--count` | `1` | Pings per host |
+| `--threads` | `50` | Parallel workers |
+| `--interval` | off | Repeat the scan every N minutes |
+| `--verbose` | off | Debug logging |
 
 ---
 
-| Use Case                        | Command                             | Description                                                                   |
-| ------------------------------- | ----------------------------------- | ----------------------------------------------------------------------------- |
-| Basic Example (Default Input)   | `ipmg`                              | Runs with default config. Creates `ip_list.xlsx` with sample IPs if missing.  |
-| Scan a Custom Excel File        | `ipmg --input network_devices.xlsx` | Scans IPs from an Excel file with an `IP Address` column.                     |
-| Scan a CSV File                 | `ipmg --input network_devices.csv`  | Scans IPs from a CSV file with an `IP Address` column.                        |
-| Scan a Text File                | `ipmg --input targets.txt`          | Scans one target per line. Blank lines and `#` comments are ignored.          |
-| Scan a Single Host              | `ipmg --input 8.8.8.8`              | Scans a literal IP passed directly on the CLI.                                |
-| Scan a CIDR Range               | `ipmg --input 192.168.1.0/24`       | Expands the CIDR block into host IPs and scans them.                          |
-| Auto-discover LAN Subnet        | `ipmg --discover`                   | Automatically detects and scans devices in the local subnet.                  |
-| Export Results to CSV + XLSX    | `ipmg --formats csv xlsx`           | Exports scan results in CSV and Excel formats.                                |
-| Create a Markdown Report        | `ipmg --formats md csv`             | Saves a readable scan report plus CSV data for tickets, handoffs, and audits. |
-| Resolve Hostnames (PTR Records) | `ipmg --resolve`                    | Performs reverse DNS (PTR) lookups for hostnames.                             |
-| Cache Hostname Lookups          | `ipmg --resolve --dns-cache-ttl 600` | Reuses PTR results for 10 minutes to make repeated scans faster.              |
-| Run Every 10 Minutes            | `ipmg --interval 10`                | Repeats the scan every 10 minutes.                                            |
+## Input formats
 
-If the default input file does not exist, IPMG creates a sample file based on the requested extension such as `.xlsx`, `.csv`, or `.txt`.
+- **Excel / CSV** — must contain an `IP Address` column:
 
----
+  | IP Address  |
+  | ----------- |
+  | 192.168.1.1 |
+  | 10.0.1.0/30 |
 
-# Sample Output Summary
+- **Text file** — one IP or CIDR per line; blank lines and `#` comments are ignored:
 
-```
-IPMG Summary
+  ```text
+  # Production DNS
+  8.8.8.8
+  192.168.1.0/30
+  ```
 
-Status        Count
-Active        132
-Inactive      12
-Unreachable   4
-Timeout       2
-
-Batch Timestamp: 2026-04-09 11:42:13
-Total Hosts: 150
-Active Rate: 88.00%
-Completion Rate: 90.67%
-Scan Duration: 6.24s
-```
+- **Command line** — a literal IP (`8.8.8.8`) or CIDR block (`10.0.0.0/24`)
 
 ---
 
-# Input Formats
+## Output
 
-IPMG accepts targets from:
-
-- Excel files: `.xlsx`, `.xls`
-- CSV files: `.csv`
-- Plain text files: `.txt`, `.list`
-- Literal IPs such as `8.8.8.8`
-- CIDR blocks such as `10.0.0.0/24`
-
-For Excel and CSV inputs, the file must contain an `IP Address` column.
-
-Example spreadsheet/CSV:
-
-| IP Address  |
-| ----------- |
-| 192.168.1.1 |
-| 10.0.0.1    |
-| 10.0.1.0/30 |
-
-Example text file:
-
-```text
-# Production DNS
-8.8.8.8
-1.1.1.1
-192.168.1.0/30
-```
-
----
-
-# Output File Format
-
-Each exported row includes batch-level metadata so a single run can be grouped reliably in downstream tools.
+Every scan prints a color-coded summary and writes result files
+(e.g. `results_20260628_120000.xlsx`). Each row includes:
 
 | IP Address | Status | Latency | Hostname   | Batch Timestamp     | Scan Duration (s) |
 | ---------- | ------ | ------- | ---------- | ------------------- | ----------------- |
 | 8.8.8.8    | Active | 12.5    | dns.google | 2026-04-09 11:42:13 | 6.24              |
 
-Possible status values include `Active`, `Inactive`, `Timeout`, `Unreachable`, `Invalid IP`, and `Error`.
+Status values: `Active`, `Inactive`, `Timeout`, `Unreachable`, `Invalid IP`, `Error`.
 
-## Markdown Reports
-
-Use `md` in `--formats` when you want an easy-to-share report:
-
-```bash
-ipmg --input targets.txt --formats md csv --resolve
-```
-
-The Markdown report includes:
-
-- Batch timestamp
-- Total host count
-- Active host count and active rate
-- Scan duration
-- Status summary table
-- Preview of the first 25 scanned hosts
-
-Example generated files:
-
-```text
-results_20260628_120000.md
-results_20260628_120000.csv
-```
+The `md` format produces a shareable Markdown report with a status summary
+table — handy for tickets, handoffs, and incident timelines.
 
 ---
 
-# Troubleshooting
+## Troubleshooting
 
-### **Command not found: ipmg**
-
-Solution:
-
-```
-pip install -e .
-```
-
-### **Permission denied output folder**
-
-Run inside a writeable directory or use:
-
-```
-sudo ipmg ...
-```
-
-### **Hostname Unresolvable**
-
-Likely missing DNS PTR records.
-
-### **Input file is rejected**
-
-Check that:
-
-- The file extension is one of `.xlsx`, `.xls`, `.csv`, `.txt`, or `.list`
-- Spreadsheet and CSV files include an `IP Address` column
-- Plain text files contain one IP or CIDR target per line
-
-### **One host crashes the scan**
-
-IPMG now records unexpected per-host failures as `Error` and continues scanning the remaining targets.
+- **`command not found: ipmg`** — make sure pip's script directory is on your
+  `PATH`, or reinstall with `pip install ipmg`.
+- **Hostname shows `Unresolvable`** — the host has no DNS PTR record.
+- **Input file rejected** — check the extension is supported and that
+  spreadsheets/CSVs include an `IP Address` column.
 
 ---
 
-# Development and Release
-
-Set up a local development environment:
+## Development
 
 ```bash
-python -m pip install --upgrade pip
 pip install -e ".[dev]"
-```
-
-Run the test suite and build the package before opening a release PR:
-
-```bash
 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q
-python -m build
 ```
 
-Releases are managed from the `main` branch by GitHub Actions. After a PR with a conventional commit such as `feat: ...` or `fix: ...` is merged, the publish workflow runs tests, creates the semantic-release version tag, builds source/wheel distributions, attaches release assets, and publishes the package to [PyPI](https://pypi.org/project/ipmg/) using the `pypi` trusted publishing environment.
-
-Use `ipmg --version` after installation to confirm the installed package version matches the latest PyPI release.
-
----
-
-# macOS GUI (PingMonitorApp – Beta)
-
-A native macOS interface for IPMG is under active development.
-
-Download Beta:
-
-👉 [https://github.com/sameeralam3127/IP_Management/releases/tag/macOS](https://github.com/sameeralam3127/IP_Management/releases/tag/macOS)
+Releases are automated: merging a conventional commit (`feat: ...`,
+`fix: ...`) to `main` triggers GitHub Actions to run tests, create a
+semantic-release tag, and publish to [PyPI](https://pypi.org/project/ipmg/).
 
 ---
 
-# License
+## License
 
-MIT License — free for commercial and personal use.
-
----
-
-Made with ❤️ using Python & uv.
+MIT — free for commercial and personal use.

--- a/src/ipmg/cli/parser.py
+++ b/src/ipmg/cli/parser.py
@@ -23,6 +23,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--discover", action="store_true")
     parser.add_argument("--resolve", action="store_true")
+    parser.add_argument(
+        "--dns-cache-ttl",
+        type=int,
+        default=300,
+        metavar="SECONDS",
+        help="Cache reverse DNS results for this many seconds (default: 300).",
+    )
     parser.add_argument("--interval", type=int)
     parser.add_argument("--verbose", action="store_true")
     return parser

--- a/src/ipmg/services/scan_service.py
+++ b/src/ipmg/services/scan_service.py
@@ -23,10 +23,10 @@ from ipmg.infrastructure.file_io import (
 )
 from ipmg.reporting.summary import print_summary
 from ipmg.utils.helpers import (
+    HostnameCache,
     clamp_int,
     console,
     current_timestamp,
-    resolve_hostname,
 )
 
 
@@ -34,6 +34,8 @@ def run_scan(args) -> None:
     args.threads = clamp_int(args.threads, 1, 500)
     args.timeout = clamp_int(args.timeout, 1, 60)
     args.count = clamp_int(args.count, 1, 10)
+    args.dns_cache_ttl = clamp_int(getattr(args, "dns_cache_ttl", 300), 0, 86400)
+    hostname_cache = HostnameCache(args.dns_cache_ttl) if args.resolve else None
 
     if not os.path.exists(args.input) and not args.discover:
         if Path(args.input).suffix.lower() in {".xlsx", ".xls", ".csv", ".txt", ".list"}:
@@ -84,7 +86,7 @@ def run_scan(args) -> None:
                     finally:
                         progress.advance(task_id)
 
-        hostnames = {ip: resolve_hostname(ip) if args.resolve else "" for ip in ip_list}
+        hostnames = {ip: hostname_cache.resolve(ip) if hostname_cache else "" for ip in ip_list}
         scan_duration = time.perf_counter() - scan_started_at
 
         df = pd.DataFrame(

--- a/src/ipmg/utils/__init__.py
+++ b/src/ipmg/utils/__init__.py
@@ -1,4 +1,5 @@
 from ipmg.utils.helpers import (
+    HostnameCache,
     clamp_int,
     console,
     current_timestamp,
@@ -6,4 +7,11 @@ from ipmg.utils.helpers import (
     timestamp_str,
 )
 
-__all__ = ["clamp_int", "console", "current_timestamp", "resolve_hostname", "timestamp_str"]
+__all__ = [
+    "HostnameCache",
+    "clamp_int",
+    "console",
+    "current_timestamp",
+    "resolve_hostname",
+    "timestamp_str",
+]

--- a/src/ipmg/utils/helpers.py
+++ b/src/ipmg/utils/helpers.py
@@ -1,7 +1,9 @@
 import logging
 import socket
+import threading
+import time
 from datetime import datetime
-from typing import Optional
+from typing import Dict, Optional, Tuple
 
 from rich.console import Console
 from rich.logging import RichHandler
@@ -28,6 +30,46 @@ RICH_THEME = Theme(
 console = Console(theme=RICH_THEME)
 
 
+class HostnameCache:
+    """Thread-safe, TTL-based cache for reverse DNS lookups."""
+
+    def __init__(self, ttl_seconds: int = 300) -> None:
+        self.ttl_seconds = max(ttl_seconds, 0)
+        self._cache: Dict[str, Tuple[float, str]] = {}
+        self._in_flight: Dict[str, threading.Event] = {}
+        self._lock = threading.Lock()
+
+    def resolve(self, ip: str) -> str:
+        with self._lock:
+            cached = self._cache.get(ip)
+            if cached and cached[0] > time.monotonic():
+                return cached[1]
+
+            completed = self._in_flight.get(ip)
+            if completed is None:
+                completed = threading.Event()
+                self._in_flight[ip] = completed
+                is_resolver = True
+            else:
+                is_resolver = False
+
+        if not is_resolver:
+            completed.wait()
+            with self._lock:
+                return self._cache.get(ip, (0.0, "Unresolvable"))[1]
+
+        try:
+            hostname = socket.gethostbyaddr(ip)[0]
+        except OSError:
+            hostname = "Unresolvable"
+        finally:
+            with self._lock:
+                self._cache[ip] = (time.monotonic() + self.ttl_seconds, hostname)
+                self._in_flight.pop(ip).set()
+
+        return hostname
+
+
 def configure_logging(verbose: bool) -> None:
     install_rich_traceback(show_locals=verbose)
     logging.basicConfig(
@@ -40,10 +82,7 @@ def configure_logging(verbose: bool) -> None:
 
 
 def resolve_hostname(ip: str) -> str:
-    try:
-        return socket.gethostbyaddr(ip)[0]
-    except Exception:
-        return "Unresolvable"
+    return HostnameCache(ttl_seconds=0).resolve(ip)
 
 
 def current_timestamp() -> datetime:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,7 @@
-from ipmg.utils import clamp_int, resolve_hostname, timestamp_str
+import threading
+import time
+
+from ipmg.utils import HostnameCache, clamp_int, resolve_hostname, timestamp_str
 
 
 def test_timestamp_str_format():
@@ -19,3 +22,50 @@ def test_resolve_hostname_safe():
     host = resolve_hostname("203.0.113.123")  # TEST-NET-3, often unrouted
     assert isinstance(host, str)
     assert len(host) > 0
+
+
+def test_hostname_cache_reuses_lookup_until_ttl_expires(monkeypatch):
+    calls = []
+    monotonic_values = iter([100.0, 101.0, 105.0, 105.0])
+
+    monkeypatch.setattr("ipmg.utils.helpers.time.monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(
+        "ipmg.utils.helpers.socket.gethostbyaddr",
+        lambda ip: calls.append(ip) or ("router.local", [], [ip]),
+    )
+
+    cache = HostnameCache(ttl_seconds=5)
+
+    assert cache.resolve("192.0.2.1") == "router.local"
+    assert cache.resolve("192.0.2.1") == "router.local"
+    assert cache.resolve("192.0.2.1") == "router.local"
+    assert calls == ["192.0.2.1", "192.0.2.1"]
+
+
+def test_hostname_cache_coordinates_simultaneous_lookups(monkeypatch):
+    calls = []
+    lookup_started = threading.Event()
+    allow_lookup_to_finish = threading.Event()
+
+    def fake_lookup(ip):
+        calls.append(ip)
+        lookup_started.set()
+        allow_lookup_to_finish.wait(timeout=1)
+        return "router.local", [], [ip]
+
+    monkeypatch.setattr("ipmg.utils.helpers.socket.gethostbyaddr", fake_lookup)
+    cache = HostnameCache(ttl_seconds=60)
+    results = []
+
+    first = threading.Thread(target=lambda: results.append(cache.resolve("192.0.2.1")))
+    second = threading.Thread(target=lambda: results.append(cache.resolve("192.0.2.1")))
+    first.start()
+    assert lookup_started.wait(timeout=1)
+    second.start()
+    time.sleep(0.01)
+    allow_lookup_to_finish.set()
+    first.join(timeout=1)
+    second.join(timeout=1)
+
+    assert calls == ["192.0.2.1"]
+    assert results == ["router.local", "router.local"]


### PR DESCRIPTION
## What changed
- add a thread-safe TTL cache for reverse DNS (PTR) lookups
- coordinate concurrent requests so one hostname lookup is performed per IP
- add `--dns-cache-ttl` (default: 300 seconds) for repeated scan runs
- document the cache option and cover TTL/concurrency behavior with tests

## Why
Repeated hostname lookups add latency and unnecessary DNS traffic, particularly for interval scans and shared target inventories.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ANSIBLE_LOCAL_TEMP=/private/tmp python3 -m pytest -q`
- `python3 -m ruff check .`
- `python3 -m build --no-isolation`

Closes #8.