### PR TITLE
ci: add security scanning workflow and secret detection

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,7 +2,12 @@ name: Security
 
 on:
   push:
+    branches: [main]
   pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
 
 jobs:
   security:
@@ -14,10 +19,16 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: "pip"
 
-      - run: pip install -r requirements.txt
+      - name: Install scanners
+        run: pip install bandit pip-audit detect-secrets
 
-      - run: pip install bandit pip-audit
+      - name: Static security analysis (bandit)
+        run: bandit -r src
 
-      - run: bandit -r .
-      - run: pip-audit
+      - name: Dependency vulnerability audit (pip-audit)
+        run: pip-audit -r requirements.txt
+
+      - name: Secret scan (detect-secrets)
+        run: git ls-files -z | xargs -0 detect-secrets-hook --baseline .secrets.baseline

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,5 @@ repos:
     rev: v1.5.0
     hooks:
       - id: detect-secrets
+        args: ["--baseline", ".secrets.baseline"]
+        exclude: uv.lock

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,127 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {},
+  "generated_at": "2026-07-13T18:10:29Z"
+}


### PR DESCRIPTION
## What changed
- New **Security** GitHub Actions workflow that runs on pushes and PRs to `main`:
  - `bandit -r src` — static security analysis of the package source
  - `pip-audit -r requirements.txt` — known-vulnerability audit of declared dependencies
  - `detect-secrets-hook --baseline .secrets.baseline` — fails if any new secret is committed
- `detect-secrets` pre-commit hook wired to the same committed baseline

## Why
Catch vulnerable dependencies, insecure code patterns, and accidentally committed credentials before they land on `main`.

## Validation
- `bandit -r src` passes locally (existing `# nosec` annotations on the validated ping subprocess calls)
- `detect-secrets-hook --baseline .secrets.baseline` passes on all tracked files (baseline has 0 findings)
- `pre-commit run detect-secrets --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)