### PR TITLE
feat: add local web dashboard with shared scan engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 ![License](https://img.shields.io/badge/license-MIT-green)
 [![Publish](https://github.com/sameeralam3127/ipmg/actions/workflows/publish.yml/badge.svg)](https://github.com/sameeralam3127/ipmg/actions/workflows/publish.yml)
 
-Scan and monitor IP networks from the command line. IPMG pings hosts in
-parallel, resolves hostnames, and exports results as Excel, CSV, JSON, or
-Markdown reports.
+Scan and monitor IP networks from the command line — or from a local web
+dashboard. IPMG pings hosts in parallel, resolves hostnames, and exports
+results as Excel, CSV, JSON, or Markdown reports.
 
 > **Security note:** only scan networks you are authorized to scan.
 > Unauthorized scanning may violate your organization's policies or the law.
@@ -65,11 +65,17 @@ ipmg --input 8.8.8.8
 # Scan a CIDR range
 ipmg --input 192.168.1.0/24
 
+# Scan an IP range
+ipmg --input 10.0.0.1-10.0.0.50
+
 # Scan targets from a file (xlsx, csv, txt, or list)
 ipmg --input targets.txt
 
 # Resolve hostnames and export CSV + a readable Markdown report
 ipmg --input targets.txt --resolve --formats md csv
+
+# Open the local web dashboard
+ipmg dashboard
 ```
 
 Running plain `ipmg` uses `ip_list.xlsx` as input and creates a sample file
@@ -77,11 +83,40 @@ if it does not exist.
 
 ---
 
+## Web dashboard
+
+```bash
+ipmg dashboard          # starts http://127.0.0.1:8080 and opens your browser
+```
+
+A modern browser UI that shares the CLI's scanning engine and runs fully
+offline — every stylesheet and script is bundled with the package, nothing
+is loaded from a CDN. It gives you:
+
+- **Dashboard** — status donut, latency trend, and recent scan overview
+- **New Scan** — upload Excel/CSV/text/JSON target files or type IPs,
+  CIDR blocks, and ranges; configure threads, timeout, and DNS options
+- **Live Monitor** — real-time progress and results over WebSockets
+- **History** — every scan stored locally in SQLite (`~/.ipmg/dashboard.db`),
+  searchable and downloadable as XLSX/CSV/JSON/Markdown
+- **Inventory** — every host seen across scans, with last status and export
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--port` | `8080` | Port to listen on |
+| `--host` | `127.0.0.1` | Bind address (local-only by default) |
+| `--no-browser` | off | Don't open the browser automatically |
+| `--db` | `~/.ipmg/dashboard.db` | History database location |
+
+`ipmg web` is an alias for `ipmg dashboard`.
+
+---
+
 ## Options
 
 | Flag | Default | Description |
 | --- | --- | --- |
-| `--input` | `ip_list.xlsx` | Targets: a file (`.xlsx`, `.xls`, `.csv`, `.txt`, `.list`), a single IP, or a CIDR block |
+| `--input` | `ip_list.xlsx` | Targets: a file (`.xlsx`, `.xls`, `.csv`, `.txt`, `.list`), a single IP, a CIDR block, or an IP range (`10.0.0.1-10.0.0.50`) |
 | `--output` | `results` | Output file name prefix |
 | `--formats` | `xlsx` | One or more of `xlsx`, `csv`, `json`, `md` |
 | `--discover` | off | Auto-detect and scan the local subnet |
@@ -112,7 +147,8 @@ if it does not exist.
   192.168.1.0/30
   ```
 
-- **Command line** — a literal IP (`8.8.8.8`) or CIDR block (`10.0.0.0/24`)
+- **Command line** — a literal IP (`8.8.8.8`), CIDR block (`10.0.0.0/24`),
+  or IP range (`10.0.0.1-10.0.0.200`)
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ dependencies = [
     "tqdm>=4.65",
     "openpyxl>=3.1",
     "rich>=13.0",
+    "fastapi>=0.110",
+    "uvicorn>=0.27",
+    "python-multipart>=0.0.9",
 ]
 
 [project.urls]
@@ -69,6 +72,7 @@ dev = [
     "ruff>=0.4",
     "pre-commit>=3.5.0",
     "python-semantic-release>=10.5.3",
+    "httpx>=0.27",
 ]
 
 [project.scripts]
@@ -86,6 +90,7 @@ dev = [
     "ruff>=0.4",
     "pre-commit>=3.5.0",
     "python-semantic-release>=10.5.3",
+    "httpx>=0.27",
 ]
 
 
@@ -114,6 +119,9 @@ package-dir = { "" = "src" }
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.package-data]
+"ipmg.web" = ["static/*.html", "static/css/*.css", "static/js/*.js"]
 
 
 # ==========================================================

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ pandas>=2.0
 tqdm>=4.65
 openpyxl>=3.1
 rich>=13.0
+fastapi>=0.110
+uvicorn>=0.27
+python-multipart>=0.0.9

--- a/src/ipmg/cli/commands.py
+++ b/src/ipmg/cli/commands.py
@@ -1,11 +1,32 @@
-from ipmg.cli.parser import build_parser
+import sys
+
+from ipmg.cli.parser import build_dashboard_parser, build_parser
 from ipmg.core.security import print_disclaimer_once
 from ipmg.services.scan_service import run_scan
 from ipmg.utils.helpers import configure_logging
 
+DASHBOARD_COMMANDS = {"dashboard", "web"}
+
 
 def run() -> None:
-    args = build_parser().parse_args()
+    argv = sys.argv[1:]
+
+    if argv and argv[0] in DASHBOARD_COMMANDS:
+        args = build_dashboard_parser().parse_args(argv[1:])
+        configure_logging(args.verbose)
+        print_disclaimer_once()
+
+        from ipmg.web.server import run_dashboard
+
+        run_dashboard(
+            host=args.host,
+            port=args.port,
+            open_browser=not args.no_browser,
+            db_path=args.db,
+        )
+        return
+
+    args = build_parser().parse_args(argv)
     configure_logging(args.verbose)
     print_disclaimer_once()
     run_scan(args)

--- a/src/ipmg/cli/parser.py
+++ b/src/ipmg/cli/parser.py
@@ -4,7 +4,10 @@ from ipmg import __version__
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser("IPMG - IP Management & Ping Monitoring Tool")
+    parser = argparse.ArgumentParser(
+        "IPMG - IP Management & Ping Monitoring Tool",
+        epilog="Run 'ipmg dashboard' to start the local web dashboard.",
+    )
     parser.add_argument(
         "--version",
         action="version",
@@ -31,5 +34,36 @@ def build_parser() -> argparse.ArgumentParser:
         help="Cache reverse DNS results for this many seconds (default: 300).",
     )
     parser.add_argument("--interval", type=int)
+    parser.add_argument("--verbose", action="store_true")
+    return parser
+
+
+def build_dashboard_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        "ipmg dashboard",
+        description="Start the local IPMG web dashboard.",
+    )
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Interface to bind (default: 127.0.0.1, local only).",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8080,
+        help="Port to listen on (default: 8080).",
+    )
+    parser.add_argument(
+        "--no-browser",
+        action="store_true",
+        help="Do not open the dashboard in a browser automatically.",
+    )
+    parser.add_argument(
+        "--db",
+        default=None,
+        metavar="PATH",
+        help="Scan history database file (default: ~/.ipmg/dashboard.db).",
+    )
     parser.add_argument("--verbose", action="store_true")
     return parser

--- a/src/ipmg/core/engine.py
+++ b/src/ipmg/core/engine.py
@@ -1,0 +1,87 @@
+"""Shared scan engine used by both the CLI and the web dashboard."""
+
+from __future__ import annotations
+
+import concurrent.futures
+from dataclasses import dataclass
+from typing import Callable, Iterable, List, Optional
+
+from ipmg.core.ping import ping_ip
+from ipmg.exceptions import PingError
+from ipmg.utils.helpers import HostnameCache, clamp_int
+
+
+@dataclass(frozen=True)
+class ScanConfig:
+    timeout: int = 2
+    count: int = 1
+    threads: int = 50
+    resolve: bool = False
+    dns_cache_ttl: int = 300
+
+    def clamped(self) -> "ScanConfig":
+        return ScanConfig(
+            timeout=clamp_int(self.timeout, 1, 60),
+            count=clamp_int(self.count, 1, 10),
+            threads=clamp_int(self.threads, 1, 500),
+            resolve=self.resolve,
+            dns_cache_ttl=clamp_int(self.dns_cache_ttl, 0, 86400),
+        )
+
+
+@dataclass(frozen=True)
+class HostResult:
+    ip: str
+    status: str
+    latency: Optional[float]
+    hostname: str = ""
+
+
+ResultCallback = Callable[[HostResult, int, int], None]
+
+
+def execute_scan(
+    ip_list: Iterable[str],
+    config: ScanConfig,
+    on_result: Optional[ResultCallback] = None,
+    should_stop: Optional[Callable[[], bool]] = None,
+) -> List[HostResult]:
+    """Ping every target concurrently and return one result per host.
+
+    ``on_result`` is invoked from the calling thread as each host finishes,
+    with the result plus completed/total counters. ``should_stop`` is polled
+    between results; returning True cancels the remaining hosts.
+    """
+    config = config.clamped()
+    ips = list(ip_list)
+    cache = HostnameCache(config.dns_cache_ttl) if config.resolve else None
+    results: List[HostResult] = []
+
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=config.threads)
+    try:
+        futures = {executor.submit(ping_ip, ip, config.timeout, config.count): ip for ip in ips}
+
+        for future in concurrent.futures.as_completed(futures):
+            if should_stop is not None and should_stop():
+                executor.shutdown(wait=False, cancel_futures=True)
+                break
+
+            ip = futures[future]
+            try:
+                status, latency = future.result()
+            except PingError:
+                executor.shutdown(wait=False, cancel_futures=True)
+                raise
+            except Exception:
+                status, latency = "Error", None
+
+            hostname = cache.resolve(ip) if cache else ""
+            result = HostResult(ip=ip, status=status, latency=latency, hostname=hostname)
+            results.append(result)
+
+            if on_result is not None:
+                on_result(result, len(results), len(ips))
+    finally:
+        executor.shutdown(wait=True)
+
+    return results

--- a/src/ipmg/infrastructure/file_io.py
+++ b/src/ipmg/infrastructure/file_io.py
@@ -40,6 +40,63 @@ def _expand_cidr(target: str) -> list[str]:
     return [str(ip) for ip in parsed.hosts()]
 
 
+def _expand_range(target: str) -> list[str]:
+    import ipaddress
+
+    start_raw, _, end_raw = target.partition("-")
+    try:
+        start = ipaddress.ip_address(start_raw.strip())
+        end = ipaddress.ip_address(end_raw.strip())
+    except ValueError:
+        # Not an IP range (e.g. a hostname containing dashes) — let callers
+        # decide whether to skip or reject the token.
+        return []
+
+    if start.version != end.version or int(end) < int(start):
+        raise FileIOError(f"Invalid IP range: {target}")
+
+    total = int(end) - int(start) + 1
+    if total > MAX_EXPANDED_TARGETS:
+        raise FileIOError(
+            f"IP range '{target}' expands to too many hosts. "
+            f"Maximum allowed hosts: {MAX_EXPANDED_TARGETS}."
+        )
+
+    return [str(start + offset) for offset in range(total)]
+
+
+def _expand_target(value: str) -> list[str]:
+    """Expand a single target token: literal IP, CIDR block, or IP range."""
+    if validate_ip(value):
+        return [value]
+    if "/" in value:
+        return _expand_cidr(value)
+    if "-" in value:
+        return _expand_range(value)
+    return []
+
+
+def parse_manual_targets(text: str) -> list[str]:
+    """Parse free-form target text: one IP, CIDR, or range per line/comma.
+
+    Blank lines and ``#`` comments are ignored. Used by the web dashboard
+    for manually entered targets.
+    """
+    targets: list[str] = []
+    for raw_line in text.splitlines():
+        line = raw_line.split("#", 1)[0]
+        for token in line.replace(",", " ").split():
+            expanded = _expand_target(token)
+            if not expanded:
+                raise FileIOError(f"Unsupported target input: {token}")
+            targets.extend(expanded)
+
+    if not targets:
+        raise FileIOError("No valid IP targets were provided.")
+
+    return _deduplicate(targets)
+
+
 def _load_from_dataframe(df: pd.DataFrame, source: str) -> list[str]:
     if "IP Address" not in df.columns:
         raise FileIOError(f"Input file '{source}' must contain an 'IP Address' column.")
@@ -49,10 +106,7 @@ def _load_from_dataframe(df: pd.DataFrame, source: str) -> list[str]:
         value = raw_value.strip()
         if not value:
             continue
-        if validate_ip(value):
-            targets.append(value)
-        elif "/" in value:
-            targets.extend(_expand_cidr(value))
+        targets.extend(_expand_target(value))
 
     if not targets:
         raise FileIOError(f"No valid IP targets were found in '{source}'.")
@@ -67,10 +121,7 @@ def _load_from_text(path: str) -> list[str]:
             value = raw_line.strip()
             if not value or value.startswith("#"):
                 continue
-            if validate_ip(value):
-                targets.append(value)
-            elif "/" in value:
-                targets.extend(_expand_cidr(value))
+            targets.extend(_expand_target(value))
 
     if not targets:
         raise FileIOError(f"No valid IP targets were found in '{path}'.")
@@ -94,14 +145,12 @@ def load_targets(source: str) -> list[str]:
             f"Supported types: {', '.join(sorted(SUPPORTED_INPUT_SUFFIXES))}."
         )
 
-    value = source.strip()
-    if validate_ip(value):
-        return [value]
-    if "/" in value:
-        return _expand_cidr(value)
+    expanded = _expand_target(source.strip())
+    if expanded:
+        return expanded
 
     raise FileIOError(
-        f"Input '{source}' is neither a readable file nor a valid IP/CIDR target."
+        f"Input '{source}' is neither a readable file nor a valid IP/CIDR/range target."
     )
 
 
@@ -170,9 +219,7 @@ def _build_markdown_report(df: pd.DataFrame) -> str:
         lines.append("| No results | 0 |")
 
     preview_columns = [
-        column
-        for column in ["IP Address", "Status", "Latency", "Hostname"]
-        if column in df.columns
+        column for column in ["IP Address", "Status", "Latency", "Hostname"] if column in df.columns
     ]
     if preview_columns:
         lines.extend(
@@ -196,6 +243,10 @@ def _build_markdown_report(df: pd.DataFrame) -> str:
 
     lines.append("")
     return "\n".join(lines)
+
+
+def build_markdown_report(df: pd.DataFrame) -> str:
+    return _build_markdown_report(df)
 
 
 def save_results(df, base: str, formats: list[str]) -> list[str]:

--- a/src/ipmg/reporting/summary.py
+++ b/src/ipmg/reporting/summary.py
@@ -31,7 +31,10 @@ def print_summary(df, batch_timestamp, duration_seconds: float) -> None:
     table.add_column("Count", justify="right", style="bright_white")
 
     for status, count in summary.items():
-        table.add_row(f"[{STATUS_STYLES.get(status, 'info')}]{status}[/{STATUS_STYLES.get(status, 'info')}]", str(count))
+        table.add_row(
+            f"[{STATUS_STYLES.get(status, 'info')}]{status}[/{STATUS_STYLES.get(status, 'info')}]",
+            str(count),
+        )
 
     metrics = Columns(
         [

--- a/src/ipmg/services/scan_service.py
+++ b/src/ipmg/services/scan_service.py
@@ -1,4 +1,3 @@
-import concurrent.futures
 import os
 import time
 from pathlib import Path
@@ -14,20 +13,14 @@ from rich.progress import (
 )
 
 from ipmg.core.discovery import discover_local_subnet
-from ipmg.core.ping import ping_ip
-from ipmg.exceptions import PingError
+from ipmg.core.engine import ScanConfig, execute_scan
 from ipmg.infrastructure.file_io import (
     create_sample_file,
     load_targets,
     save_results,
 )
 from ipmg.reporting.summary import print_summary
-from ipmg.utils.helpers import (
-    HostnameCache,
-    clamp_int,
-    console,
-    current_timestamp,
-)
+from ipmg.utils.helpers import clamp_int, console, current_timestamp
 
 
 def run_scan(args) -> None:
@@ -35,7 +28,14 @@ def run_scan(args) -> None:
     args.timeout = clamp_int(args.timeout, 1, 60)
     args.count = clamp_int(args.count, 1, 10)
     args.dns_cache_ttl = clamp_int(getattr(args, "dns_cache_ttl", 300), 0, 86400)
-    hostname_cache = HostnameCache(args.dns_cache_ttl) if args.resolve else None
+
+    config = ScanConfig(
+        timeout=args.timeout,
+        count=args.count,
+        threads=args.threads,
+        resolve=args.resolve,
+        dns_cache_ttl=args.dns_cache_ttl,
+    )
 
     if not os.path.exists(args.input) and not args.discover:
         if Path(args.input).suffix.lower() in {".xlsx", ".xls", ".csv", ".txt", ".list"}:
@@ -60,46 +60,37 @@ def run_scan(args) -> None:
             )
         )
 
-        results = {}
-        with concurrent.futures.ThreadPoolExecutor(max_workers=args.threads) as executor:
-            futures = {executor.submit(ping_ip, ip, args.timeout, args.count): ip for ip in ip_list}
+        with Progress(
+            SpinnerColumn(style="ipmg.accent"),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(bar_width=None, complete_style="green", finished_style="bright_green"),
+            TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+            TextColumn("[bold]{task.completed}/{task.total}[/bold]"),
+            TimeElapsedColumn(),
+            console=console,
+        ) as progress:
+            task_id = progress.add_task(
+                "[ipmg.accent]Scanning hosts[/ipmg.accent]", total=len(ip_list)
+            )
+            host_results = execute_scan(
+                ip_list,
+                config,
+                on_result=lambda _result, _done, _total: progress.advance(task_id),
+            )
 
-            with Progress(
-                SpinnerColumn(style="ipmg.accent"),
-                TextColumn("[progress.description]{task.description}"),
-                BarColumn(bar_width=None, complete_style="green", finished_style="bright_green"),
-                TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
-                TextColumn("[bold]{task.completed}/{task.total}[/bold]"),
-                TimeElapsedColumn(),
-                console=console,
-            ) as progress:
-                task_id = progress.add_task("[ipmg.accent]Scanning hosts[/ipmg.accent]", total=len(ip_list))
-
-                for future in concurrent.futures.as_completed(futures):
-                    ip = futures[future]
-                    try:
-                        results[ip] = future.result()
-                    except PingError:
-                        raise
-                    except Exception:
-                        results[ip] = ("Error", None)
-                    finally:
-                        progress.advance(task_id)
-
-        hostnames = {ip: hostname_cache.resolve(ip) if hostname_cache else "" for ip in ip_list}
         scan_duration = time.perf_counter() - scan_started_at
 
         df = pd.DataFrame(
             [
                 {
-                    "IP Address": ip,
-                    "Status": status,
-                    "Latency": latency,
-                    "Hostname": hostnames[ip],
+                    "IP Address": result.ip,
+                    "Status": result.status,
+                    "Latency": result.latency,
+                    "Hostname": result.hostname,
                     "Batch Timestamp": batch_timestamp,
                     "Scan Duration (s)": round(scan_duration, 3),
                 }
-                for ip, (status, latency) in results.items()
+                for result in host_results
             ]
         )
 

--- a/src/ipmg/web/__init__.py
+++ b/src/ipmg/web/__init__.py
@@ -1,0 +1,1 @@
+"""Local web dashboard for IPMG (FastAPI backend + bundled frontend)."""

--- a/src/ipmg/web/app.py
+++ b/src/ipmg/web/app.py
@@ -1,0 +1,277 @@
+"""FastAPI application powering the IPMG dashboard.
+
+Everything is served locally: the REST API under /api/v1, a WebSocket for
+live scan progress, and the bundled frontend (no CDN assets, fully offline).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import tempfile
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
+from fastapi import APIRouter, FastAPI, HTTPException, UploadFile, WebSocket
+from fastapi.responses import Response
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel, Field
+from starlette.websockets import WebSocketDisconnect
+
+from ipmg import __version__
+from ipmg.core.engine import ScanConfig
+from ipmg.exceptions import FileIOError
+from ipmg.infrastructure.file_io import (
+    SUPPORTED_INPUT_SUFFIXES,
+    build_markdown_report,
+    load_targets,
+    parse_manual_targets,
+)
+from ipmg.web.db import DEFAULT_DB_PATH, Database
+from ipmg.web.manager import ScanManager
+
+STATIC_DIR = Path(__file__).parent / "static"
+
+REPORT_MEDIA_TYPES = {
+    "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "csv": "text/csv",
+    "json": "application/json",
+    "md": "text/markdown",
+}
+
+
+class ScanRequest(BaseModel):
+    targets: Optional[str] = Field(default=None, description="Free-form target text")
+    ips: Optional[List[str]] = Field(default=None, description="Pre-parsed IP list")
+    source: str = "manual"
+    timeout: int = 2
+    count: int = 1
+    threads: int = 50
+    resolve: bool = False
+    dns_cache_ttl: int = 300
+
+
+def _targets_from_json(data: Any) -> List[str]:
+    if isinstance(data, dict):
+        data = data.get("targets") or data.get("ips") or []
+    if not isinstance(data, list):
+        raise FileIOError("JSON uploads must contain a list of targets.")
+
+    lines = []
+    for entry in data:
+        if isinstance(entry, str):
+            lines.append(entry)
+        elif isinstance(entry, dict):
+            value = entry.get("IP Address") or entry.get("ip") or entry.get("target")
+            if value:
+                lines.append(str(value))
+    return parse_manual_targets("\n".join(lines))
+
+
+def _parse_scan_targets(request: ScanRequest) -> List[str]:
+    try:
+        if request.ips:
+            return parse_manual_targets("\n".join(request.ips))
+        if request.targets:
+            return parse_manual_targets(request.targets)
+        raise FileIOError("Provide 'targets' text or an 'ips' list.")
+    except FileIOError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+def _results_dataframe(scan: Dict[str, Any], rows: List[Dict[str, Any]]) -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "IP Address": row["ip"],
+                "Status": row["status"],
+                "Latency": row["latency"],
+                "Hostname": row["hostname"],
+                "Batch Timestamp": scan["started_at"],
+                "Scan Duration (s)": scan["duration_s"],
+            }
+            for row in rows
+        ]
+    )
+
+
+def _render_report(df: pd.DataFrame, fmt: str) -> bytes:
+    if fmt == "xlsx":
+        buffer = io.BytesIO()
+        df.to_excel(buffer, index=False)
+        return buffer.getvalue()
+    if fmt == "csv":
+        return df.to_csv(index=False).encode("utf-8")
+    if fmt == "json":
+        return df.to_json(orient="records").encode("utf-8")
+    return build_markdown_report(df).encode("utf-8")
+
+
+def _parse_upload(filename: str, payload: bytes) -> List[str]:
+    suffix = Path(filename).suffix.lower()
+
+    if suffix == ".json":
+        return _targets_from_json(json.loads(payload.decode("utf-8")))
+
+    if suffix in SUPPORTED_INPUT_SUFFIXES:
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as handle:
+            handle.write(payload)
+            temp_path = handle.name
+        try:
+            return load_targets(temp_path)
+        finally:
+            Path(temp_path).unlink(missing_ok=True)
+
+    raise FileIOError(
+        f"Unsupported file type '{suffix or '<none>'}'. Supported: "
+        f"{', '.join(sorted(SUPPORTED_INPUT_SUFFIXES | {'.json'}))}."
+    )
+
+
+def _register_overview_routes(api: APIRouter, database: Database) -> None:
+    @api.get("/stats")
+    def stats() -> Dict[str, Any]:
+        return database.overview()
+
+    @api.get("/assets")
+    def assets() -> List[Dict[str, Any]]:
+        return database.inventory()
+
+    @api.get("/scans")
+    def list_scans(limit: int = 50) -> List[Dict[str, Any]]:
+        return database.list_scans(limit=max(1, min(limit, 500)))
+
+
+def _register_scan_routes(api: APIRouter, database: Database, manager: ScanManager) -> None:
+    @api.post("/scans", status_code=201)
+    def create_scan(request: ScanRequest) -> Dict[str, Any]:
+        ips = _parse_scan_targets(request)
+        config = ScanConfig(
+            timeout=request.timeout,
+            count=request.count,
+            threads=request.threads,
+            resolve=request.resolve,
+            dns_cache_ttl=request.dns_cache_ttl,
+        ).clamped()
+        scan_id = manager.start_scan(ips, config, source=request.source)
+        return {"id": scan_id, "total": len(ips)}
+
+    @api.get("/scans/{scan_id}")
+    def get_scan(scan_id: int) -> Dict[str, Any]:
+        scan = database.get_scan(scan_id)
+        if scan is None:
+            raise HTTPException(status_code=404, detail="Scan not found")
+        return scan
+
+    @api.get("/scans/{scan_id}/results")
+    def get_results(
+        scan_id: int,
+        status: Optional[str] = None,
+        search: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        if database.get_scan(scan_id) is None:
+            raise HTTPException(status_code=404, detail="Scan not found")
+        return database.get_results(scan_id, status=status, search=search)
+
+    @api.post("/scans/{scan_id}/cancel")
+    def cancel_scan(scan_id: int) -> Dict[str, Any]:
+        if not manager.cancel(scan_id):
+            raise HTTPException(status_code=409, detail="Scan is not running")
+        return {"id": scan_id, "cancelling": True}
+
+    @api.delete("/scans/{scan_id}", status_code=204)
+    def delete_scan(scan_id: int) -> Response:
+        if not database.delete_scan(scan_id):
+            raise HTTPException(status_code=404, detail="Scan not found")
+        return Response(status_code=204)
+
+
+def _register_report_routes(api: APIRouter, database: Database) -> None:
+    @api.get("/scans/{scan_id}/report")
+    def download_report(scan_id: int, fmt: str = "csv") -> Response:
+        if fmt not in REPORT_MEDIA_TYPES:
+            raise HTTPException(status_code=400, detail=f"Unsupported format: {fmt}")
+
+        scan = database.get_scan(scan_id)
+        if scan is None:
+            raise HTTPException(status_code=404, detail="Scan not found")
+
+        df = _results_dataframe(scan, database.get_results(scan_id))
+        content = _render_report(df, fmt)
+
+        timestamp = str(scan["started_at"]).replace(" ", "_").replace(":", "")
+        filename = f"ipmg_scan_{scan_id}_{timestamp}.{fmt}"
+        return Response(
+            content=content,
+            media_type=REPORT_MEDIA_TYPES[fmt],
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
+
+
+def _register_upload_route(api: APIRouter) -> None:
+    @api.post("/upload")
+    async def upload_targets(file: UploadFile) -> Dict[str, Any]:
+        payload = await file.read()
+        try:
+            targets = _parse_upload(file.filename or "", payload)
+        except FileIOError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except (ValueError, UnicodeDecodeError) as exc:
+            raise HTTPException(status_code=400, detail=f"Could not parse file: {exc}") from exc
+
+        return {"filename": file.filename, "count": len(targets), "targets": targets}
+
+
+def _register_websocket(app: FastAPI, manager: ScanManager) -> None:
+    @app.websocket("/api/v1/ws")
+    async def websocket_events(websocket: WebSocket) -> None:
+        await websocket.accept()
+        queue = manager.subscribe()
+
+        async def forward_events() -> None:
+            while True:
+                event = await queue.get()
+                await websocket.send_json(event)
+
+        forward_task = asyncio.create_task(forward_events())
+        try:
+            # Detect client disconnects promptly; the dashboard never sends
+            # messages, so this loop only ends when the socket closes.
+            while True:
+                await websocket.receive_text()
+        except WebSocketDisconnect:
+            pass
+        finally:
+            forward_task.cancel()
+            manager.unsubscribe(queue)
+
+
+def create_app(db: Optional[Database] = None) -> FastAPI:
+    database = db if db is not None else Database(DEFAULT_DB_PATH)
+    manager = ScanManager(database)
+
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI):
+        manager.attach_loop(asyncio.get_running_loop())
+        yield
+
+    app = FastAPI(title="IPMG Dashboard", version=__version__, lifespan=lifespan)
+    app.state.db = database
+    app.state.manager = manager
+
+    api = APIRouter(prefix="/api/v1")
+    _register_overview_routes(api, database)
+    _register_scan_routes(api, database, manager)
+    _register_report_routes(api, database)
+    _register_upload_route(api)
+    app.include_router(api)
+
+    _register_websocket(app, manager)
+
+    if STATIC_DIR.is_dir():
+        app.mount("/", StaticFiles(directory=STATIC_DIR, html=True), name="static")
+
+    return app

--- a/src/ipmg/web/db.py
+++ b/src/ipmg/web/db.py
@@ -1,0 +1,242 @@
+"""SQLite persistence for dashboard scan history. Thread-safe via a lock."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from ipmg.core.engine import HostResult
+
+DEFAULT_DB_PATH = Path.home() / ".ipmg" / "dashboard.db"
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS scans (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    started_at TEXT NOT NULL,
+    finished_at TEXT,
+    duration_s REAL,
+    source TEXT NOT NULL,
+    total INTEGER NOT NULL DEFAULT 0,
+    completed INTEGER NOT NULL DEFAULT 0,
+    status TEXT NOT NULL DEFAULT 'running',
+    config TEXT NOT NULL DEFAULT '{}',
+    error TEXT
+);
+
+CREATE TABLE IF NOT EXISTS results (
+    scan_id INTEGER NOT NULL REFERENCES scans(id) ON DELETE CASCADE,
+    ip TEXT NOT NULL,
+    status TEXT NOT NULL,
+    latency REAL,
+    hostname TEXT NOT NULL DEFAULT '',
+    checked_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_results_scan ON results(scan_id);
+CREATE INDEX IF NOT EXISTS idx_results_ip ON results(ip);
+"""
+
+
+def _now() -> str:
+    return datetime.now().isoformat(sep=" ", timespec="seconds")
+
+
+class Database:
+    def __init__(self, path: Path | str = DEFAULT_DB_PATH) -> None:
+        self._path = str(path)
+        self._lock = threading.Lock()
+        Path(self._path).parent.mkdir(parents=True, exist_ok=True)
+        with self._session() as conn:
+            conn.executescript(_SCHEMA)
+
+    @contextmanager
+    def _session(self):
+        with self._lock:
+            conn = sqlite3.connect(self._path)
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA foreign_keys = ON")
+            try:
+                with conn:
+                    yield conn
+            finally:
+                conn.close()
+
+    # ------------------------------------------------------------- scans
+
+    def create_scan(self, source: str, total: int, config: Dict[str, Any]) -> int:
+        with self._session() as conn:
+            cursor = conn.execute(
+                "INSERT INTO scans (started_at, source, total, config) VALUES (?, ?, ?, ?)",
+                (_now(), source, total, json.dumps(config)),
+            )
+            return int(cursor.lastrowid)
+
+    def add_result(self, scan_id: int, result: HostResult) -> None:
+        with self._session() as conn:
+            conn.execute(
+                "INSERT INTO results (scan_id, ip, status, latency, hostname, checked_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (scan_id, result.ip, result.status, result.latency, result.hostname, _now()),
+            )
+            conn.execute(
+                "UPDATE scans SET completed = completed + 1 WHERE id = ?",
+                (scan_id,),
+            )
+
+    def finish_scan(self, scan_id: int, status: str, duration_s: float) -> None:
+        with self._session() as conn:
+            conn.execute(
+                "UPDATE scans SET status = ?, finished_at = ?, duration_s = ? WHERE id = ?",
+                (status, _now(), round(duration_s, 3), scan_id),
+            )
+
+    def fail_scan(self, scan_id: int, error: str) -> None:
+        with self._session() as conn:
+            conn.execute(
+                "UPDATE scans SET status = 'failed', finished_at = ?, error = ? WHERE id = ?",
+                (_now(), error, scan_id),
+            )
+
+    def get_scan(self, scan_id: int) -> Optional[Dict[str, Any]]:
+        with self._session() as conn:
+            row = conn.execute("SELECT * FROM scans WHERE id = ?", (scan_id,)).fetchone()
+            if row is None:
+                return None
+            scan = self._scan_dict(row)
+            scan["status_counts"] = self._status_counts(conn, scan_id)
+            scan["avg_latency"] = self._avg_latency(conn, scan_id)
+            return scan
+
+    def list_scans(self, limit: int = 50) -> List[Dict[str, Any]]:
+        with self._session() as conn:
+            rows = conn.execute("SELECT * FROM scans ORDER BY id DESC LIMIT ?", (limit,)).fetchall()
+            scans = []
+            for row in rows:
+                scan = self._scan_dict(row)
+                scan["status_counts"] = self._status_counts(conn, scan["id"])
+                scan["avg_latency"] = self._avg_latency(conn, scan["id"])
+                scans.append(scan)
+            return scans
+
+    def delete_scan(self, scan_id: int) -> bool:
+        with self._session() as conn:
+            cursor = conn.execute("DELETE FROM scans WHERE id = ?", (scan_id,))
+            return cursor.rowcount > 0
+
+    # ----------------------------------------------------------- results
+
+    def get_results(
+        self,
+        scan_id: int,
+        status: Optional[str] = None,
+        search: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        query = "SELECT ip, status, latency, hostname, checked_at " "FROM results WHERE scan_id = ?"
+        params: List[Any] = [scan_id]
+        if status:
+            query += " AND status = ?"
+            params.append(status)
+        if search:
+            query += " AND (ip LIKE ? OR hostname LIKE ?)"
+            like = f"%{search}%"
+            params.extend([like, like])
+        query += " ORDER BY rowid"
+
+        with self._session() as conn:
+            return [dict(row) for row in conn.execute(query, params).fetchall()]
+
+    # ------------------------------------------------------- aggregates
+
+    def overview(self) -> Dict[str, Any]:
+        with self._session() as conn:
+            scan_count = conn.execute("SELECT COUNT(*) FROM scans").fetchone()[0]
+            host_count = conn.execute("SELECT COUNT(DISTINCT ip) FROM results").fetchone()[0]
+
+            latest_row = conn.execute(
+                "SELECT * FROM scans WHERE status != 'running' ORDER BY id DESC LIMIT 1"
+            ).fetchone()
+            latest = None
+            if latest_row is not None:
+                latest = self._scan_dict(latest_row)
+                latest["status_counts"] = self._status_counts(conn, latest["id"])
+                latest["avg_latency"] = self._avg_latency(conn, latest["id"])
+
+            running_rows = conn.execute(
+                "SELECT * FROM scans WHERE status = 'running' ORDER BY id DESC"
+            ).fetchall()
+
+            trend_rows = conn.execute(
+                "SELECT s.id, s.started_at, s.total, "
+                "  (SELECT COUNT(*) FROM results r "
+                "   WHERE r.scan_id = s.id AND r.status = 'Active') AS active, "
+                "  (SELECT AVG(r.latency) FROM results r "
+                "   WHERE r.scan_id = s.id AND r.status = 'Active') AS avg_latency "
+                "FROM scans s WHERE s.status = 'complete' "
+                "ORDER BY s.id DESC LIMIT 15"
+            ).fetchall()
+
+            return {
+                "scan_count": scan_count,
+                "host_count": host_count,
+                "latest_scan": latest,
+                "running_scans": [self._scan_dict(row) for row in running_rows],
+                "trend": [dict(row) for row in reversed(trend_rows)],
+            }
+
+    def inventory(self) -> List[Dict[str, Any]]:
+        query = (
+            "SELECT r.ip, "
+            "  (SELECT r2.hostname FROM results r2 "
+            "   WHERE r2.ip = r.ip AND r2.hostname != '' "
+            "   ORDER BY r2.rowid DESC LIMIT 1) AS hostname, "
+            "  (SELECT r3.status FROM results r3 "
+            "   WHERE r3.ip = r.ip ORDER BY r3.rowid DESC LIMIT 1) AS status, "
+            "  AVG(CASE WHEN r.status = 'Active' THEN r.latency END) AS avg_latency, "
+            "  MAX(CASE WHEN r.status = 'Active' THEN r.checked_at END) AS last_seen, "
+            "  MAX(r.checked_at) AS last_checked, "
+            "  MAX(r.scan_id) AS last_scan_id, "
+            "  COUNT(DISTINCT r.scan_id) AS scan_count "
+            "FROM results r GROUP BY r.ip"
+        )
+        with self._session() as conn:
+            rows = [dict(row) for row in conn.execute(query).fetchall()]
+
+        def sort_key(row: Dict[str, Any]):
+            import ipaddress
+
+            try:
+                return (0, int(ipaddress.ip_address(row["ip"])))
+            except ValueError:
+                return (1, 0)
+
+        rows.sort(key=sort_key)
+        return rows
+
+    # ------------------------------------------------------------ helpers
+
+    @staticmethod
+    def _scan_dict(row: sqlite3.Row) -> Dict[str, Any]:
+        scan = dict(row)
+        scan["config"] = json.loads(scan.get("config") or "{}")
+        return scan
+
+    @staticmethod
+    def _status_counts(conn: sqlite3.Connection, scan_id: int) -> Dict[str, int]:
+        rows = conn.execute(
+            "SELECT status, COUNT(*) AS count FROM results WHERE scan_id = ? GROUP BY status",
+            (scan_id,),
+        ).fetchall()
+        return {row["status"]: row["count"] for row in rows}
+
+    @staticmethod
+    def _avg_latency(conn: sqlite3.Connection, scan_id: int) -> Optional[float]:
+        value = conn.execute(
+            "SELECT AVG(latency) FROM results WHERE scan_id = ? AND status = 'Active'",
+            (scan_id,),
+        ).fetchone()[0]
+        return round(value, 2) if value is not None else None

--- a/src/ipmg/web/manager.py
+++ b/src/ipmg/web/manager.py
@@ -1,0 +1,119 @@
+"""Runs scans in background threads and broadcasts progress to WebSockets."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from dataclasses import asdict
+from typing import Any, Dict, List, Optional, Set
+
+from ipmg.core.engine import HostResult, ScanConfig, execute_scan
+from ipmg.web.db import Database
+
+
+class ScanManager:
+    def __init__(self, db: Database) -> None:
+        self._db = db
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._subscribers: Set[asyncio.Queue] = set()
+        self._stops: Dict[int, threading.Event] = {}
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------ subscriptions
+
+    def attach_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        self._loop = loop
+
+    def subscribe(self) -> asyncio.Queue:
+        queue: asyncio.Queue = asyncio.Queue()
+        with self._lock:
+            self._subscribers.add(queue)
+        return queue
+
+    def unsubscribe(self, queue: asyncio.Queue) -> None:
+        with self._lock:
+            self._subscribers.discard(queue)
+
+    def _broadcast(self, event: Dict[str, Any]) -> None:
+        loop = self._loop
+        if loop is None or loop.is_closed():
+            return
+        with self._lock:
+            queues = list(self._subscribers)
+        for queue in queues:
+            loop.call_soon_threadsafe(queue.put_nowait, event)
+
+    # -------------------------------------------------------------- scans
+
+    def start_scan(self, ips: List[str], config: ScanConfig, source: str) -> int:
+        scan_id = self._db.create_scan(source, len(ips), asdict(config))
+        stop = threading.Event()
+        with self._lock:
+            self._stops[scan_id] = stop
+
+        thread = threading.Thread(
+            target=self._run,
+            args=(scan_id, ips, config, stop),
+            name=f"ipmg-scan-{scan_id}",
+            daemon=True,
+        )
+        thread.start()
+        return scan_id
+
+    def cancel(self, scan_id: int) -> bool:
+        with self._lock:
+            stop = self._stops.get(scan_id)
+        if stop is None:
+            return False
+        stop.set()
+        return True
+
+    def is_running(self, scan_id: int) -> bool:
+        with self._lock:
+            return scan_id in self._stops
+
+    # ------------------------------------------------------------ worker
+
+    def _run(
+        self,
+        scan_id: int,
+        ips: List[str],
+        config: ScanConfig,
+        stop: threading.Event,
+    ) -> None:
+        started_at = time.perf_counter()
+        self._broadcast({"type": "scan_started", "scan_id": scan_id, "total": len(ips)})
+
+        def on_result(result: HostResult, completed: int, total: int) -> None:
+            self._db.add_result(scan_id, result)
+            self._broadcast(
+                {
+                    "type": "result",
+                    "scan_id": scan_id,
+                    "completed": completed,
+                    "total": total,
+                    "result": asdict(result),
+                }
+            )
+
+        try:
+            execute_scan(ips, config, on_result=on_result, should_stop=stop.is_set)
+        except Exception as exc:
+            self._db.fail_scan(scan_id, str(exc))
+            final_status = "failed"
+        else:
+            final_status = "cancelled" if stop.is_set() else "complete"
+            self._db.finish_scan(scan_id, final_status, time.perf_counter() - started_at)
+        finally:
+            with self._lock:
+                self._stops.pop(scan_id, None)
+
+        self._broadcast(
+            {
+                "type": "scan_finished",
+                "scan_id": scan_id,
+                "status": final_status,
+                "duration_s": round(time.perf_counter() - started_at, 3),
+            }
+        )

--- a/src/ipmg/web/server.py
+++ b/src/ipmg/web/server.py
@@ -1,0 +1,53 @@
+"""Launches the dashboard: uvicorn server plus automatic browser opening."""
+
+from __future__ import annotations
+
+import ipaddress
+import threading
+import webbrowser
+from pathlib import Path
+from typing import Optional
+
+import uvicorn
+from rich.panel import Panel
+
+from ipmg.utils.helpers import console
+from ipmg.web.app import create_app
+from ipmg.web.db import DEFAULT_DB_PATH, Database
+
+
+def _display_host(host: str) -> str:
+    try:
+        if ipaddress.ip_address(host).is_unspecified:
+            return "127.0.0.1"
+    except ValueError:
+        pass
+    return host
+
+
+def run_dashboard(
+    host: str = "127.0.0.1",
+    port: int = 8080,
+    open_browser: bool = True,
+    db_path: Optional[str] = None,
+) -> None:
+    database = Database(Path(db_path) if db_path else DEFAULT_DB_PATH)
+    app = create_app(database)
+    url = f"http://{_display_host(host)}:{port}"
+
+    console.print(
+        Panel.fit(
+            (
+                "[ipmg.accent]Starting IPMG Dashboard...[/ipmg.accent]\n\n"
+                f"Dashboard Available:\n\n[bold bright_white]{url}[/bold bright_white]\n\n"
+                "Press CTRL+C to stop."
+            ),
+            title="[ipmg.accent]IPMG Dashboard[/ipmg.accent]",
+            border_style="ipmg.accent",
+        )
+    )
+
+    if open_browser:
+        threading.Timer(1.0, webbrowser.open, args=(url,)).start()
+
+    uvicorn.run(app, host=host, port=port, log_level="warning")

--- a/src/ipmg/web/static/css/app.css
+++ b/src/ipmg/web/static/css/app.css
@@ -1,0 +1,312 @@
+/* IPMG Dashboard — fully local styles, no external assets. */
+
+:root {
+  --bg: #f9f9f7;
+  --surface: #fcfcfb;
+  --text: #0b0b0b;
+  --text-2: #52514e;
+  --muted: #898781;
+  --grid: #e1e0d9;
+  --border: rgba(11, 11, 11, 0.10);
+  --accent: #2a78d6;
+  --accent-ink: #ffffff;
+  --st-active: #0ca30c;
+  --st-inactive: #d03b3b;
+  --st-timeout: #fab219;
+  --st-unreachable: #ec835a;
+  --st-error: #4a3aa7;
+  --st-invalid: #898781;
+  --danger: #d03b3b;
+  --shadow: 0 1px 2px rgba(11, 11, 11, 0.05);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0d0d0d;
+    --surface: #1a1a19;
+    --text: #ffffff;
+    --text-2: #c3c2b7;
+    --grid: #2c2c2a;
+    --border: rgba(255, 255, 255, 0.10);
+    --accent: #3987e5;
+    --st-error: #9085e9;
+    --shadow: none;
+  }
+}
+
+:root[data-theme="light"] {
+  --bg: #f9f9f7;
+  --surface: #fcfcfb;
+  --text: #0b0b0b;
+  --text-2: #52514e;
+  --grid: #e1e0d9;
+  --border: rgba(11, 11, 11, 0.10);
+  --accent: #2a78d6;
+  --st-error: #4a3aa7;
+  --shadow: 0 1px 2px rgba(11, 11, 11, 0.05);
+}
+
+:root[data-theme="dark"] {
+  --bg: #0d0d0d;
+  --surface: #1a1a19;
+  --text: #ffffff;
+  --text-2: #c3c2b7;
+  --grid: #2c2c2a;
+  --border: rgba(255, 255, 255, 0.10);
+  --accent: #3987e5;
+  --st-error: #9085e9;
+  --shadow: none;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  font-size: 14px;
+  color: var(--text);
+  background: var(--bg);
+}
+
+.app { display: flex; min-height: 100vh; }
+
+/* ------------------------------------------------------------ sidebar */
+
+.sidebar {
+  width: 200px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  padding: 16px 12px;
+  border-right: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  height: 100vh;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--accent);
+  padding: 4px 8px 18px;
+}
+
+.nav { display: flex; flex-direction: column; gap: 2px; }
+
+.nav a {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 10px;
+  border-radius: 8px;
+  color: var(--text-2);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.nav a svg { width: 17px; height: 17px; fill: currentColor; flex-shrink: 0; }
+.nav a:hover { background: color-mix(in srgb, var(--text) 6%, transparent); }
+.nav a.active { background: color-mix(in srgb, var(--accent) 14%, transparent); color: var(--accent); }
+
+.sidebar-footer {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px;
+}
+
+.conn { font-size: 12px; color: var(--muted); }
+.conn[data-state="open"]::before { content: "● "; color: var(--st-active); }
+.conn[data-state="connecting"]::before { content: "● "; color: var(--st-timeout); }
+.conn[data-state="closed"]::before { content: "● "; color: var(--st-inactive); }
+
+/* --------------------------------------------------------------- main */
+
+.main { flex: 1; padding: 24px 28px 48px; max-width: 1200px; }
+
+.page-title { font-size: 20px; font-weight: 700; margin: 0 0 4px; }
+.page-sub { color: var(--text-2); margin: 0 0 20px; }
+
+.grid { display: grid; gap: 14px; }
+.tiles { grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); margin-bottom: 14px; }
+.two-col { grid-template-columns: 1fr 1fr; }
+@media (max-width: 900px) { .two-col { grid-template-columns: 1fr; } }
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 16px;
+  box-shadow: var(--shadow);
+}
+
+.card h3 { margin: 0 0 12px; font-size: 13px; font-weight: 600; color: var(--text-2); }
+
+.tile .value { font-size: 26px; font-weight: 700; }
+.tile .label { color: var(--muted); font-size: 12px; margin-top: 2px; }
+
+/* -------------------------------------------------------------- forms */
+
+label.field { display: block; margin-bottom: 12px; color: var(--text-2); font-weight: 500; }
+label.field span { display: block; margin-bottom: 4px; font-size: 12.5px; }
+
+input[type="text"], input[type="number"], select, textarea {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  color: var(--text);
+  font: inherit;
+}
+
+textarea { min-height: 130px; resize: vertical; font-family: ui-monospace, "SF Mono", Menlo, monospace; }
+
+input:focus, select:focus, textarea:focus { outline: 2px solid var(--accent); outline-offset: -1px; }
+
+.check { display: flex; align-items: center; gap: 8px; color: var(--text-2); margin-bottom: 12px; }
+.check input { accent-color: var(--accent); width: 15px; height: 15px; }
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 16px;
+  border: none;
+  border-radius: 8px;
+  background: var(--accent);
+  color: var(--accent-ink);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+.btn:hover { filter: brightness(1.08); }
+.btn:disabled { opacity: 0.55; cursor: not-allowed; }
+
+.btn.secondary {
+  background: transparent;
+  color: var(--text-2);
+  border: 1px solid var(--border);
+}
+.btn.danger { background: transparent; color: var(--danger); border: 1px solid var(--danger); }
+
+.ghost-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text-2);
+  padding: 6px 10px;
+  font: inherit;
+  cursor: pointer;
+}
+.ghost-btn svg { fill: currentColor; }
+.ghost-btn:hover { background: color-mix(in srgb, var(--text) 6%, transparent); }
+
+.dropzone {
+  border: 1.5px dashed var(--border);
+  border-radius: 10px;
+  padding: 22px;
+  text-align: center;
+  color: var(--muted);
+  cursor: pointer;
+  margin-bottom: 12px;
+}
+.dropzone.dragover { border-color: var(--accent); color: var(--accent); }
+
+/* ------------------------------------------------------------- tables */
+
+.table-wrap { overflow-x: auto; }
+
+table { width: 100%; border-collapse: collapse; }
+
+th, td {
+  text-align: left;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--grid);
+  white-space: nowrap;
+}
+
+th { color: var(--muted); font-size: 12px; font-weight: 600; }
+td { font-variant-numeric: tabular-nums; }
+tbody tr:hover { background: color-mix(in srgb, var(--text) 4%, transparent); }
+tr.click { cursor: pointer; }
+
+.pill { display: inline-flex; align-items: center; gap: 6px; color: var(--text); }
+.pill::before { content: ""; width: 8px; height: 8px; border-radius: 50%; background: var(--pill-color, var(--muted)); }
+
+/* ----------------------------------------------------------- progress */
+
+.progress-track {
+  height: 10px;
+  border-radius: 5px;
+  background: color-mix(in srgb, var(--text) 8%, transparent);
+  overflow: hidden;
+}
+.progress-fill {
+  height: 100%;
+  border-radius: 5px;
+  background: var(--accent);
+  transition: width 0.25s ease;
+}
+.progress-meta { display: flex; justify-content: space-between; color: var(--text-2); margin-top: 8px; }
+
+/* -------------------------------------------------------------- misc */
+
+.banner { padding: 10px 14px; border-radius: 8px; margin-bottom: 14px; border: 1px solid var(--border); }
+.banner.ok { border-color: var(--st-active); color: var(--st-active); }
+.banner.err { border-color: var(--danger); color: var(--danger); }
+
+.toolbar { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; margin-bottom: 14px; }
+.toolbar input, .toolbar select { width: auto; }
+.toolbar .spacer { flex: 1; }
+
+.empty { color: var(--muted); text-align: center; padding: 32px 0; }
+
+.legend { display: flex; flex-direction: column; gap: 8px; }
+.legend-item { display: flex; align-items: center; gap: 8px; color: var(--text-2); }
+.legend-item .swatch { width: 10px; height: 10px; border-radius: 3px; flex-shrink: 0; }
+.legend-item .count { margin-left: auto; font-variant-numeric: tabular-nums; color: var(--text); font-weight: 600; }
+
+.chart-row { display: flex; gap: 20px; align-items: center; flex-wrap: wrap; }
+
+.donut-center-value { font-size: 24px; font-weight: 700; fill: var(--text); }
+.donut-center-label { font-size: 11px; fill: var(--muted); }
+
+.axis-label { font-size: 10.5px; fill: var(--muted); font-variant-numeric: tabular-nums; }
+.gridline { stroke: var(--grid); stroke-width: 1; }
+.trend-line { stroke: var(--accent); stroke-width: 2; fill: none; }
+.trend-dot { fill: var(--accent); stroke: var(--surface); stroke-width: 2; }
+.trend-label { font-size: 11px; fill: var(--text-2); font-variant-numeric: tabular-nums; }
+
+.tooltip {
+  position: fixed;
+  z-index: 10;
+  pointer-events: none;
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 7px 10px;
+  font-size: 12.5px;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
+  max-width: 260px;
+}
+.tooltip .t-title { font-weight: 600; margin-bottom: 2px; }
+.tooltip .t-sub { color: var(--text-2); }
+
+@media (max-width: 720px) {
+  .app { flex-direction: column; }
+  .sidebar { width: 100%; height: auto; position: static; flex-direction: row; align-items: center; gap: 10px; }
+  .brand { padding: 0; }
+  .nav { flex-direction: row; flex-wrap: wrap; }
+  .nav a { padding: 7px 9px; }
+  .sidebar-footer { margin: 0 0 0 auto; flex-direction: row; align-items: center; }
+  .main { padding: 18px 14px 40px; }
+}

--- a/src/ipmg/web/static/index.html
+++ b/src/ipmg/web/static/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>IPMG Dashboard</title>
+  <link rel="stylesheet" href="/css/app.css">
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Ccircle cx='16' cy='16' r='13' fill='none' stroke='%232a78d6' stroke-width='3'/%3E%3Ccircle cx='16' cy='16' r='5' fill='%232a78d6'/%3E%3C/svg%3E">
+</head>
+<body>
+  <div class="app">
+    <aside class="sidebar">
+      <div class="brand">
+        <svg viewBox="0 0 32 32" width="26" height="26" aria-hidden="true">
+          <circle cx="16" cy="16" r="13" fill="none" stroke="currentColor" stroke-width="3"/>
+          <circle cx="16" cy="16" r="5" fill="currentColor"/>
+        </svg>
+        <span>IPMG</span>
+      </div>
+      <nav class="nav">
+        <a href="#/" data-route="dashboard">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 13h8V3H3zm0 8h8v-6H3zm10 0h8V11h-8zm0-18v6h8V3z"/></svg>
+          Dashboard
+        </a>
+        <a href="#/new" data-route="new">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2zm5 11h-4v4h-2v-4H7v-2h4V7h2v4h4z"/></svg>
+          New Scan
+        </a>
+        <a href="#/monitor" data-route="monitor">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 12h4l3-9 4 18 3-9h4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          Live Monitor
+        </a>
+        <a href="#/history" data-route="history">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M13 3a9 9 0 1 0 8.5 12h-2.2A7 7 0 1 1 13 5a6.9 6.9 0 0 1 4.9 2H14v2h7V2h-2v2.4A8.9 8.9 0 0 0 13 3zm-1 5v5l4.3 2.5.7-1.2-3.5-2V8z"/></svg>
+          History
+        </a>
+        <a href="#/inventory" data-route="inventory">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 4h16v4H4zm0 6h16v4H4zm0 6h16v4H4z" fill="none" stroke="currentColor" stroke-width="2"/></svg>
+          Inventory
+        </a>
+      </nav>
+      <div class="sidebar-footer">
+        <button id="theme-toggle" class="ghost-btn" type="button" title="Toggle theme">
+          <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true"><path d="M12 3a9 9 0 1 0 9 9 7 7 0 0 1-9-9z"/></svg>
+          Theme
+        </button>
+        <span id="conn-status" class="conn" data-state="connecting">connecting</span>
+      </div>
+    </aside>
+    <main id="view" class="main" aria-live="polite"></main>
+  </div>
+  <div id="tooltip" class="tooltip" hidden></div>
+  <script type="module" src="/js/app.js"></script>
+</body>
+</html>

--- a/src/ipmg/web/static/js/api.js
+++ b/src/ipmg/web/static/js/api.js
@@ -1,0 +1,95 @@
+// REST + WebSocket client for the local IPMG API. No external dependencies.
+
+const BASE = "/api/v1";
+
+async function request(path, options = {}) {
+  const response = await fetch(`${BASE}${path}`, options);
+  if (!response.ok) {
+    let detail = `${response.status} ${response.statusText}`;
+    try {
+      const body = await response.json();
+      if (body.detail) detail = body.detail;
+    } catch {
+      /* non-JSON error body */
+    }
+    throw new Error(detail);
+  }
+  if (response.status === 204) return null;
+  return response.json();
+}
+
+export const api = {
+  stats: () => request("/stats"),
+  assets: () => request("/assets"),
+  scans: (limit = 50) => request(`/scans?limit=${limit}`),
+  scan: (id) => request(`/scans/${id}`),
+  results: (id, { status, search } = {}) => {
+    const params = new URLSearchParams();
+    if (status) params.set("status", status);
+    if (search) params.set("search", search);
+    const suffix = params.toString() ? `?${params}` : "";
+    return request(`/scans/${id}/results${suffix}`);
+  },
+  startScan: (payload) =>
+    request("/scans", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    }),
+  cancelScan: (id) => request(`/scans/${id}/cancel`, { method: "POST" }),
+  deleteScan: (id) => request(`/scans/${id}`, { method: "DELETE" }),
+  upload: (file) => {
+    const form = new FormData();
+    form.append("file", file);
+    return request("/upload", { method: "POST", body: form });
+  },
+  reportUrl: (id, fmt) => `${BASE}/scans/${id}/report?fmt=${fmt}`,
+};
+
+// ------------------------------------------------------------ websocket
+
+const listeners = new Set();
+let socket = null;
+let reconnectDelay = 1000;
+
+export function onEvent(handler) {
+  listeners.add(handler);
+  return () => listeners.delete(handler);
+}
+
+function setConnState(state) {
+  const el = document.getElementById("conn-status");
+  if (el) {
+    el.dataset.state = state;
+    el.textContent = state === "open" ? "live" : state;
+  }
+}
+
+export function connect() {
+  const protocol = location.protocol === "https:" ? "wss:" : "ws:";
+  socket = new WebSocket(`${protocol}//${location.host}${BASE}/ws`);
+  setConnState("connecting");
+
+  socket.onopen = () => {
+    reconnectDelay = 1000;
+    setConnState("open");
+  };
+
+  socket.onmessage = (message) => {
+    let event;
+    try {
+      event = JSON.parse(message.data);
+    } catch {
+      return;
+    }
+    listeners.forEach((handler) => handler(event));
+  };
+
+  socket.onclose = () => {
+    setConnState("closed");
+    setTimeout(connect, reconnectDelay);
+    reconnectDelay = Math.min(reconnectDelay * 2, 15000);
+  };
+
+  socket.onerror = () => socket.close();
+}

--- a/src/ipmg/web/static/js/app.js
+++ b/src/ipmg/web/static/js/app.js
@@ -1,0 +1,73 @@
+// App shell: hash router, theme toggle, and WebSocket bootstrap.
+
+import { connect } from "./api.js";
+import {
+  dashboardView,
+  historyView,
+  inventoryView,
+  monitorView,
+  newScanView,
+  scanDetailView,
+} from "./views.js";
+
+const routes = [
+  { pattern: /^#?\/?$/, name: "dashboard", view: dashboardView },
+  { pattern: /^#\/new$/, name: "new", view: newScanView },
+  { pattern: /^#\/monitor(?:\/(\d+))?$/, name: "monitor", view: monitorView },
+  { pattern: /^#\/history$/, name: "history", view: historyView },
+  { pattern: /^#\/scan\/(\d+)$/, name: "history", view: scanDetailView },
+  { pattern: /^#\/inventory$/, name: "inventory", view: inventoryView },
+];
+
+async function render() {
+  const root = document.getElementById("view");
+  // Let the previous view tear down its subscriptions.
+  root.dispatchEvent(new CustomEvent("view:destroy"));
+  root.replaceChildren();
+
+  const hash = location.hash || "#/";
+  const route = routes.find((candidate) => candidate.pattern.test(hash)) || routes[0];
+  const match = hash.match(route.pattern);
+
+  document.querySelectorAll(".nav a").forEach((link) => {
+    link.classList.toggle("active", link.dataset.route === route.name);
+  });
+
+  try {
+    await route.view(root, match && match[1] ? Number(match[1]) : undefined);
+  } catch (err) {
+    root.replaceChildren();
+    const banner = document.createElement("div");
+    banner.className = "banner err";
+    banner.textContent = `Failed to load page: ${err.message}`;
+    root.appendChild(banner);
+  }
+}
+
+// ------------------------------------------------------------ theme
+
+function applyTheme(theme) {
+  if (theme === "light" || theme === "dark") {
+    document.documentElement.dataset.theme = theme;
+  } else {
+    delete document.documentElement.dataset.theme;
+  }
+}
+
+function initTheme() {
+  applyTheme(localStorage.getItem("ipmg-theme"));
+  document.getElementById("theme-toggle").addEventListener("click", () => {
+    const systemDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    const current = document.documentElement.dataset.theme || (systemDark ? "dark" : "light");
+    const next = current === "dark" ? "light" : "dark";
+    localStorage.setItem("ipmg-theme", next);
+    applyTheme(next);
+  });
+}
+
+// -------------------------------------------------------------- boot
+
+window.addEventListener("hashchange", render);
+initTheme();
+connect();
+render();

--- a/src/ipmg/web/static/js/charts.js
+++ b/src/ipmg/web/static/js/charts.js
@@ -1,0 +1,277 @@
+// Hand-rolled SVG charts: status donut and latency trend. No libraries.
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+// Fixed status order — the CVD-validated adjacency for donut segments.
+export const STATUS_ORDER = [
+  "Active",
+  "Timeout",
+  "Inactive",
+  "Error",
+  "Unreachable",
+  "Invalid IP",
+];
+
+export const STATUS_COLORS = {
+  Active: "var(--st-active)",
+  Timeout: "var(--st-timeout)",
+  Inactive: "var(--st-inactive)",
+  Error: "var(--st-error)",
+  Unreachable: "var(--st-unreachable)",
+  "Invalid IP": "var(--st-invalid)",
+};
+
+function el(name, attrs = {}) {
+  const node = document.createElementNS(SVG_NS, name);
+  for (const [key, value] of Object.entries(attrs)) node.setAttribute(key, value);
+  return node;
+}
+
+const tooltip = () => document.getElementById("tooltip");
+
+export function showTooltip(evt, title, sub) {
+  const tip = tooltip();
+  if (!tip) return;
+  tip.innerHTML = "";
+  const titleEl = document.createElement("div");
+  titleEl.className = "t-title";
+  titleEl.textContent = title;
+  tip.appendChild(titleEl);
+  if (sub) {
+    const subEl = document.createElement("div");
+    subEl.className = "t-sub";
+    subEl.textContent = sub;
+    tip.appendChild(subEl);
+  }
+  tip.hidden = false;
+  const pad = 12;
+  const rect = tip.getBoundingClientRect();
+  let x = evt.clientX + pad;
+  let y = evt.clientY + pad;
+  if (x + rect.width > window.innerWidth - pad) x = evt.clientX - rect.width - pad;
+  if (y + rect.height > window.innerHeight - pad) y = evt.clientY - rect.height - pad;
+  tip.style.left = `${x}px`;
+  tip.style.top = `${y}px`;
+}
+
+export function hideTooltip() {
+  const tip = tooltip();
+  if (tip) tip.hidden = true;
+}
+
+/**
+ * Donut of status counts with a centered total, plus a legend listing every
+ * status with its count (identity is never carried by color alone).
+ */
+export function statusDonut(counts, { centerLabel = "hosts" } = {}) {
+  const entries = STATUS_ORDER.filter((status) => counts[status] > 0).map(
+    (status) => [status, counts[status]]
+  );
+  const total = entries.reduce((sum, [, count]) => sum + count, 0);
+
+  const size = 160;
+  const radius = 62;
+  const stroke = 22;
+  const center = size / 2;
+  const circumference = 2 * Math.PI * radius;
+
+  const svg = el("svg", {
+    viewBox: `0 0 ${size} ${size}`,
+    width: size,
+    height: size,
+    role: "img",
+    "aria-label": `Status distribution for ${total} hosts`,
+  });
+
+  if (total === 0) {
+    const track = el("circle", {
+      cx: center,
+      cy: center,
+      r: radius,
+      fill: "none",
+      stroke: "var(--grid)",
+      "stroke-width": stroke,
+    });
+    svg.appendChild(track);
+  }
+
+  let offset = -circumference / 4; // start at 12 o'clock
+  for (const [status, count] of entries) {
+    const fraction = count / total;
+    const arc = el("circle", {
+      cx: center,
+      cy: center,
+      r: radius,
+      fill: "none",
+      stroke: STATUS_COLORS[status] || "var(--st-invalid)",
+      "stroke-width": stroke,
+      "stroke-dasharray": `${fraction * circumference} ${circumference}`,
+      "stroke-dashoffset": -offset,
+      // 2px surface gap between segments
+      "stroke-linecap": "butt",
+    });
+    const gap = el("circle", {
+      cx: center,
+      cy: center,
+      r: radius,
+      fill: "none",
+      stroke: "var(--surface)",
+      "stroke-width": stroke + 2,
+      "stroke-dasharray": `2 ${circumference - 2}`,
+      "stroke-dashoffset": -offset,
+    });
+    arc.addEventListener("mousemove", (evt) =>
+      showTooltip(evt, `${status}: ${count}`, `${((count / total) * 100).toFixed(1)}% of ${total}`)
+    );
+    arc.addEventListener("mouseleave", hideTooltip);
+    svg.appendChild(arc);
+    if (entries.length > 1) svg.appendChild(gap);
+    offset += fraction * circumference;
+  }
+
+  const value = el("text", {
+    x: center,
+    y: center - 2,
+    "text-anchor": "middle",
+    class: "donut-center-value",
+  });
+  value.textContent = String(total);
+  const label = el("text", {
+    x: center,
+    y: center + 16,
+    "text-anchor": "middle",
+    class: "donut-center-label",
+  });
+  label.textContent = centerLabel;
+  svg.append(value, label);
+
+  const legend = document.createElement("div");
+  legend.className = "legend";
+  if (!entries.length) {
+    const empty = document.createElement("div");
+    empty.className = "legend-item";
+    empty.textContent = "No results yet";
+    legend.appendChild(empty);
+  }
+  for (const [status, count] of entries) {
+    const item = document.createElement("div");
+    item.className = "legend-item";
+    const swatch = document.createElement("span");
+    swatch.className = "swatch";
+    swatch.style.background = STATUS_COLORS[status];
+    const name = document.createElement("span");
+    name.textContent = status;
+    const countEl = document.createElement("span");
+    countEl.className = "count";
+    countEl.textContent = String(count);
+    item.append(swatch, name, countEl);
+    legend.appendChild(item);
+  }
+
+  const wrap = document.createElement("div");
+  wrap.className = "chart-row";
+  wrap.append(svg, legend);
+  return wrap;
+}
+
+/**
+ * Single-series trend line (average active latency per completed scan).
+ * One axis, hairline grid, hover dots with tooltips, last point labeled.
+ */
+export function latencyTrend(points) {
+  const data = points.filter((point) => point.avg_latency != null);
+  const width = 460;
+  const height = 170;
+  const margin = { top: 14, right: 44, bottom: 22, left: 40 };
+
+  const svg = el("svg", {
+    viewBox: `0 0 ${width} ${height}`,
+    width: "100%",
+    role: "img",
+    "aria-label": "Average latency per scan",
+    preserveAspectRatio: "xMidYMid meet",
+  });
+
+  if (data.length < 2) {
+    const note = el("text", {
+      x: width / 2,
+      y: height / 2,
+      "text-anchor": "middle",
+      class: "axis-label",
+    });
+    note.textContent = "Run two or more scans to see the latency trend.";
+    svg.appendChild(note);
+    return svg;
+  }
+
+  const plotW = width - margin.left - margin.right;
+  const plotH = height - margin.top - margin.bottom;
+  const maxY = Math.max(...data.map((point) => point.avg_latency)) * 1.15 || 1;
+
+  const x = (index) => margin.left + (index / (data.length - 1)) * plotW;
+  const y = (value) => margin.top + plotH - (value / maxY) * plotH;
+
+  for (let tick = 0; tick <= 3; tick += 1) {
+    const value = (maxY / 3) * tick;
+    const gy = y(value);
+    svg.appendChild(
+      el("line", { x1: margin.left, y1: gy, x2: width - margin.right, y2: gy, class: "gridline" })
+    );
+    const tickLabel = el("text", {
+      x: margin.left - 6,
+      y: gy + 3.5,
+      "text-anchor": "end",
+      class: "axis-label",
+    });
+    tickLabel.textContent = value >= 10 ? Math.round(value) : value.toFixed(1);
+    svg.appendChild(tickLabel);
+  }
+
+  const path = data
+    .map((point, index) => `${index === 0 ? "M" : "L"}${x(index).toFixed(1)},${y(point.avg_latency).toFixed(1)}`)
+    .join(" ");
+  svg.appendChild(el("path", { d: path, class: "trend-line" }));
+
+  data.forEach((point, index) => {
+    const dot = el("circle", {
+      cx: x(index),
+      cy: y(point.avg_latency),
+      r: 4,
+      class: "trend-dot",
+    });
+    const hit = el("circle", {
+      cx: x(index),
+      cy: y(point.avg_latency),
+      r: 11,
+      fill: "transparent",
+    });
+    hit.addEventListener("mousemove", (evt) =>
+      showTooltip(
+        evt,
+        `${point.avg_latency.toFixed(1)} ms avg`,
+        `Scan #${point.id} — ${point.started_at} — ${point.active}/${point.total} active`
+      )
+    );
+    hit.addEventListener("mouseleave", hideTooltip);
+    svg.append(dot, hit);
+  });
+
+  const last = data[data.length - 1];
+  const lastLabel = el("text", {
+    x: x(data.length - 1) + 8,
+    y: y(last.avg_latency) + 4,
+    class: "trend-label",
+  });
+  lastLabel.textContent = `${last.avg_latency.toFixed(1)} ms`;
+  svg.appendChild(lastLabel);
+
+  const axisTitle = el("text", {
+    x: margin.left,
+    y: height - 6,
+    class: "axis-label",
+  });
+  axisTitle.textContent = `Avg active latency (ms), last ${data.length} scans`;
+  svg.appendChild(axisTitle);
+
+  return svg;
+}

--- a/src/ipmg/web/static/js/views.js
+++ b/src/ipmg/web/static/js/views.js
@@ -1,0 +1,525 @@
+// Page views for the IPMG dashboard. Each view renders into the <main> node.
+
+import { api, onEvent } from "./api.js";
+import { STATUS_COLORS, latencyTrend, statusDonut } from "./charts.js";
+
+const REPORT_FORMATS = ["xlsx", "csv", "json", "md"];
+
+function h(tag, attrs = {}, ...children) {
+  const node = document.createElement(tag);
+  for (const [key, value] of Object.entries(attrs)) {
+    if (key === "class") node.className = value;
+    else if (key.startsWith("on")) node.addEventListener(key.slice(2), value);
+    else if (value !== undefined && value !== null) node.setAttribute(key, value);
+  }
+  for (const child of children.flat()) {
+    if (child == null) continue;
+    node.append(child.nodeType ? child : document.createTextNode(String(child)));
+  }
+  return node;
+}
+
+function statusPill(status) {
+  const pill = h("span", { class: "pill" }, status);
+  pill.style.setProperty("--pill-color", STATUS_COLORS[status] || "var(--muted)");
+  return pill;
+}
+
+const SCAN_STATE_COLORS = {
+  running: "var(--st-timeout)",
+  complete: "var(--st-active)",
+  failed: "var(--st-inactive)",
+  cancelled: "var(--muted)",
+};
+
+function scanStatePill(state) {
+  const pill = h("span", { class: "pill" }, state);
+  pill.style.setProperty("--pill-color", SCAN_STATE_COLORS[state] || "var(--muted)");
+  return pill;
+}
+
+function fmtLatency(latency) {
+  return latency == null ? "—" : `${Number(latency).toFixed(1)} ms`;
+}
+
+function fmtDuration(seconds) {
+  return seconds == null ? "—" : `${Number(seconds).toFixed(1)}s`;
+}
+
+function activeRate(scan) {
+  const active = scan.status_counts?.Active ?? 0;
+  return scan.total ? `${((active / scan.total) * 100).toFixed(1)}%` : "—";
+}
+
+function tile(value, label) {
+  return h("div", { class: "card tile" }, h("div", { class: "value" }, value), h("div", { class: "label" }, label));
+}
+
+function resultsTable(rows) {
+  if (!rows.length) return h("div", { class: "empty" }, "No results.");
+  return h(
+    "div",
+    { class: "table-wrap" },
+    h(
+      "table",
+      {},
+      h("thead", {}, h("tr", {}, ...["IP Address", "Status", "Latency", "Hostname", "Checked"].map((t) => h("th", {}, t)))),
+      h(
+        "tbody",
+        {},
+        rows.map((row) =>
+          h(
+            "tr",
+            {},
+            h("td", {}, row.ip),
+            h("td", {}, statusPill(row.status)),
+            h("td", {}, fmtLatency(row.latency)),
+            h("td", {}, row.hostname || "—"),
+            h("td", {}, row.checked_at || "")
+          )
+        )
+      )
+    )
+  );
+}
+
+function scansTable(scans, { onOpen }) {
+  if (!scans.length) return h("div", { class: "empty" }, "No scans yet — start one from “New Scan”.");
+  return h(
+    "div",
+    { class: "table-wrap" },
+    h(
+      "table",
+      {},
+      h(
+        "thead",
+        {},
+        h("tr", {}, ...["#", "Started", "Source", "Hosts", "Active rate", "Avg latency", "Duration", "Status"].map((t) => h("th", {}, t)))
+      ),
+      h(
+        "tbody",
+        {},
+        scans.map((scan) =>
+          h(
+            "tr",
+            { class: "click", onclick: () => onOpen(scan) },
+            h("td", {}, String(scan.id)),
+            h("td", {}, scan.started_at),
+            h("td", {}, scan.source),
+            h("td", {}, `${scan.completed}/${scan.total}`),
+            h("td", {}, activeRate(scan)),
+            h("td", {}, fmtLatency(scan.avg_latency)),
+            h("td", {}, fmtDuration(scan.duration_s)),
+            h("td", {}, scanStatePill(scan.status))
+          )
+        )
+      )
+    )
+  );
+}
+
+// ------------------------------------------------------------ dashboard
+
+export async function dashboardView(root) {
+  const stats = await api.stats();
+  const latest = stats.latest_scan;
+
+  root.append(
+    h("h1", { class: "page-title" }, "Dashboard"),
+    h("p", { class: "page-sub" }, "Overview of your local network scans.")
+  );
+
+  const tiles = h("div", { class: "grid tiles" });
+  tiles.append(
+    tile(String(stats.scan_count), "Total scans"),
+    tile(String(stats.host_count), "Hosts tracked"),
+    tile(latest ? String(latest.total) : "—", "Hosts in last scan"),
+    tile(latest ? activeRate(latest) : "—", "Active rate (last scan)"),
+    tile(latest && latest.avg_latency != null ? `${latest.avg_latency} ms` : "—", "Avg latency (last scan)")
+  );
+  root.append(tiles);
+
+  if (stats.running_scans.length) {
+    const running = stats.running_scans[0];
+    root.append(
+      h(
+        "div",
+        { class: "banner ok" },
+        `Scan #${running.id} is running (${running.completed}/${running.total}) — `,
+        h("a", { href: `#/monitor/${running.id}` }, "watch live")
+      )
+    );
+  }
+
+  const charts = h("div", { class: "grid two-col" });
+  const statusCard = h("div", { class: "card" }, h("h3", {}, "Last scan status"));
+  statusCard.append(
+    latest ? statusDonut(latest.status_counts || {}) : h("div", { class: "empty" }, "No completed scans yet.")
+  );
+  const trendCard = h("div", { class: "card" }, h("h3", {}, "Latency trend"));
+  trendCard.append(latencyTrend(stats.trend || []));
+  charts.append(statusCard, trendCard);
+  root.append(charts);
+
+  const recent = h("div", { class: "card", style: "margin-top:14px" }, h("h3", {}, "Recent scans"));
+  const scans = await api.scans(8);
+  recent.append(scansTable(scans, { onOpen: (scan) => (location.hash = `#/scan/${scan.id}`) }));
+  root.append(recent);
+}
+
+// ------------------------------------------------------------- new scan
+
+export async function newScanView(root) {
+  root.append(
+    h("h1", { class: "page-title" }, "New Scan"),
+    h("p", { class: "page-sub" }, "Upload a target file or enter IPs, CIDR blocks, or ranges manually.")
+  );
+
+  const banner = h("div");
+  const targetsInput = h("textarea", {
+    placeholder: "192.168.1.10\n192.168.1.0/24\n10.0.0.1-10.0.0.200\n# comments are ignored",
+  });
+
+  const fileInput = h("input", { type: "file", accept: ".xlsx,.xls,.csv,.txt,.list,.json", hidden: "" });
+  const dropzone = h(
+    "div",
+    { class: "dropzone" },
+    "Drop an Excel / CSV / text / JSON target file here, or click to browse."
+  );
+  dropzone.addEventListener("click", () => fileInput.click());
+  ["dragover", "dragleave", "drop"].forEach((type) =>
+    dropzone.addEventListener(type, (evt) => {
+      evt.preventDefault();
+      dropzone.classList.toggle("dragover", type === "dragover");
+      if (type === "drop" && evt.dataTransfer.files.length) handleFile(evt.dataTransfer.files[0]);
+    })
+  );
+  fileInput.addEventListener("change", () => fileInput.files.length && handleFile(fileInput.files[0]));
+
+  async function handleFile(file) {
+    banner.replaceChildren();
+    try {
+      const parsed = await api.upload(file);
+      targetsInput.value = parsed.targets.join("\n");
+      banner.append(h("div", { class: "banner ok" }, `Loaded ${parsed.count} targets from ${parsed.filename}.`));
+    } catch (err) {
+      banner.append(h("div", { class: "banner err" }, `Upload failed: ${err.message}`));
+    }
+  }
+
+  const numField = (label, name, value, attrs = {}) =>
+    h("label", { class: "field" }, h("span", {}, label), h("input", { type: "number", name, value, ...attrs }));
+
+  const form = h("form", {});
+  const configGrid = h("div", { class: "grid", style: "grid-template-columns:repeat(auto-fit,minmax(130px,1fr))" });
+  configGrid.append(
+    numField("Ping count", "count", "1", { min: 1, max: 10 }),
+    numField("Timeout (s)", "timeout", "2", { min: 1, max: 60 }),
+    numField("Threads", "threads", "50", { min: 1, max: 500 }),
+    numField("DNS cache TTL (s)", "dns_cache_ttl", "300", { min: 0, max: 86400 })
+  );
+
+  const resolveCheck = h("label", { class: "check" }, h("input", { type: "checkbox", name: "resolve" }), "Resolve hostnames (reverse DNS)");
+  const submit = h("button", { class: "btn", type: "submit" }, "Start Scan");
+
+  form.append(
+    h("label", { class: "field" }, h("span", {}, "Targets"), targetsInput),
+    configGrid,
+    resolveCheck,
+    submit
+  );
+
+  form.addEventListener("submit", async (evt) => {
+    evt.preventDefault();
+    banner.replaceChildren();
+    submit.disabled = true;
+    try {
+      const data = new FormData(form);
+      const scan = await api.startScan({
+        targets: targetsInput.value,
+        source: "dashboard",
+        count: Number(data.get("count")),
+        timeout: Number(data.get("timeout")),
+        threads: Number(data.get("threads")),
+        dns_cache_ttl: Number(data.get("dns_cache_ttl")),
+        resolve: data.get("resolve") === "on",
+      });
+      location.hash = `#/monitor/${scan.id}`;
+    } catch (err) {
+      banner.append(h("div", { class: "banner err" }, `Could not start scan: ${err.message}`));
+      submit.disabled = false;
+    }
+  });
+
+  root.append(banner, h("div", { class: "card" }, dropzone, fileInput, form));
+}
+
+// ---------------------------------------------------------- live monitor
+
+export async function monitorView(root, scanId) {
+  root.append(h("h1", { class: "page-title" }, "Live Monitor"));
+
+  let scan = null;
+  if (scanId) {
+    scan = await api.scan(scanId).catch(() => null);
+  } else {
+    const stats = await api.stats();
+    scan = stats.running_scans[0] || stats.latest_scan;
+  }
+
+  if (!scan) {
+    root.append(h("div", { class: "empty" }, "No scans yet — start one from “New Scan”."));
+    return;
+  }
+
+  const counts = { ...(scan.status_counts || {}) };
+  let completed = scan.completed;
+  const total = scan.total;
+
+  root.append(
+    h(
+      "p",
+      { class: "page-sub" },
+      `Scan #${scan.id} · started ${scan.started_at} · ${scan.source}`
+    )
+  );
+
+  const fill = h("div", { class: "progress-fill" });
+  const meta = h("div", { class: "progress-meta" });
+  const progressCard = h("div", { class: "card" }, h("div", { class: "progress-track" }, fill), meta);
+
+  const donutHost = h("div");
+  const donutCard = h("div", { class: "card" }, h("h3", {}, "Status distribution"), donutHost);
+
+  const tableHost = h("div");
+  const tableCard = h("div", { class: "card", style: "margin-top:14px" }, h("h3", {}, "Results (live)"), tableHost);
+
+  const cancelBtn = h("button", { class: "btn danger", type: "button" }, "Cancel scan");
+  cancelBtn.addEventListener("click", () => api.cancelScan(scan.id).catch(() => {}));
+
+  const statusLine = h("div", { class: "banner" });
+
+  const rows = await api.results(scan.id).catch(() => []);
+  rows.reverse();
+
+  function redraw() {
+    fill.style.width = total ? `${(completed / total) * 100}%` : "0%";
+    meta.replaceChildren(
+      h("span", {}, `${completed} / ${total} hosts`),
+      h("span", {}, total ? `${((completed / total) * 100).toFixed(0)}%` : "")
+    );
+    donutHost.replaceChildren(statusDonut(counts));
+    tableHost.replaceChildren(resultsTable(rows.slice(0, 100)));
+  }
+
+  function setFinished(status, duration) {
+    statusLine.className = `banner ${status === "complete" ? "ok" : "err"}`;
+    statusLine.replaceChildren(
+      `Scan ${status}${duration ? ` in ${fmtDuration(duration)}` : ""} — `,
+      h("a", { href: `#/scan/${scan.id}` }, "open full results")
+    );
+    cancelBtn.remove();
+  }
+
+  if (scan.status === "running") {
+    root.append(statusLine, progressCard, h("div", { class: "toolbar", style: "margin-top:14px" }, cancelBtn));
+    statusLine.textContent = "Scanning…";
+  } else {
+    setFinished(scan.status, scan.duration_s);
+    root.append(statusLine, progressCard);
+  }
+
+  root.append(h("div", { class: "grid two-col", style: "margin-top:14px" }, donutCard), tableCard);
+  redraw();
+
+  const unsubscribe = onEvent((event) => {
+    if (event.scan_id !== scan.id) return;
+    if (event.type === "result") {
+      completed = event.completed;
+      counts[event.result.status] = (counts[event.result.status] || 0) + 1;
+      rows.unshift(event.result);
+      redraw();
+    } else if (event.type === "scan_finished") {
+      setFinished(event.status, event.duration_s);
+    }
+  });
+  root.addEventListener("view:destroy", unsubscribe, { once: true });
+}
+
+// -------------------------------------------------------------- history
+
+export async function historyView(root) {
+  root.append(
+    h("h1", { class: "page-title" }, "Scan History"),
+    h("p", { class: "page-sub" }, "Every scan stored in the local database.")
+  );
+  const scans = await api.scans(100);
+  root.append(
+    h("div", { class: "card" }, scansTable(scans, { onOpen: (scan) => (location.hash = `#/scan/${scan.id}`) }))
+  );
+}
+
+// ----------------------------------------------------------- scan detail
+
+export async function scanDetailView(root, scanId) {
+  const scan = await api.scan(scanId).catch(() => null);
+  if (!scan) {
+    root.append(h("div", { class: "empty" }, "Scan not found."));
+    return;
+  }
+
+  root.append(
+    h("h1", { class: "page-title" }, `Scan #${scan.id}`),
+    h(
+      "p",
+      { class: "page-sub" },
+      `${scan.started_at} · ${scan.source} · ${scan.status} · ${fmtDuration(scan.duration_s)}`
+    )
+  );
+
+  const tiles = h("div", { class: "grid tiles" });
+  tiles.append(
+    tile(String(scan.total), "Hosts"),
+    tile(String(scan.status_counts?.Active ?? 0), "Active"),
+    tile(activeRate(scan), "Active rate"),
+    tile(scan.avg_latency != null ? `${scan.avg_latency} ms` : "—", "Avg latency")
+  );
+  root.append(tiles);
+
+  const toolbar = h("div", { class: "toolbar" });
+  const search = h("input", { type: "text", placeholder: "Search IP or hostname…" });
+  const statusFilter = h(
+    "select",
+    {},
+    h("option", { value: "" }, "All statuses"),
+    ...Object.keys(scan.status_counts || {}).map((status) => h("option", { value: status }, status))
+  );
+  toolbar.append(search, statusFilter, h("span", { class: "spacer" }));
+
+  for (const fmt of REPORT_FORMATS) {
+    toolbar.append(
+      h("a", { class: "ghost-btn", href: api.reportUrl(scan.id, fmt), download: "" }, fmt.toUpperCase())
+    );
+  }
+
+  const deleteBtn = h("button", { class: "btn danger", type: "button" }, "Delete");
+  deleteBtn.addEventListener("click", async () => {
+    if (!confirm(`Delete scan #${scan.id} and its results?`)) return;
+    await api.deleteScan(scan.id);
+    location.hash = "#/history";
+  });
+  toolbar.append(deleteBtn);
+
+  const donutCard = h("div", { class: "card" }, h("h3", {}, "Status distribution"), statusDonut(scan.status_counts || {}));
+  const tableHost = h("div", { class: "card", style: "margin-top:14px" });
+
+  async function refreshTable() {
+    const rows = await api.results(scan.id, {
+      status: statusFilter.value || undefined,
+      search: search.value || undefined,
+    });
+    tableHost.replaceChildren(h("h3", {}, `Results (${rows.length})`), resultsTable(rows));
+  }
+
+  let debounce;
+  search.addEventListener("input", () => {
+    clearTimeout(debounce);
+    debounce = setTimeout(refreshTable, 250);
+  });
+  statusFilter.addEventListener("change", refreshTable);
+
+  root.append(toolbar, h("div", { class: "grid two-col" }, donutCard), tableHost);
+  await refreshTable();
+}
+
+// ------------------------------------------------------------ inventory
+
+export async function inventoryView(root) {
+  root.append(
+    h("h1", { class: "page-title" }, "Inventory"),
+    h("p", { class: "page-sub" }, "Every host seen across all stored scans.")
+  );
+
+  const assets = await api.assets();
+  const toolbar = h("div", { class: "toolbar" });
+  const search = h("input", { type: "text", placeholder: "Filter by IP or hostname…" });
+  const exportBtn = h("button", { class: "ghost-btn", type: "button" }, "Export CSV");
+  toolbar.append(search, h("span", { class: "spacer" }), exportBtn);
+
+  const tableHost = h("div", { class: "card" });
+
+  function matching() {
+    const term = search.value.trim().toLowerCase();
+    if (!term) return assets;
+    return assets.filter(
+      (asset) =>
+        asset.ip.toLowerCase().includes(term) || (asset.hostname || "").toLowerCase().includes(term)
+    );
+  }
+
+  function draw() {
+    const rows = matching();
+    if (!rows.length) {
+      tableHost.replaceChildren(h("div", { class: "empty" }, "No hosts recorded yet."));
+      return;
+    }
+    tableHost.replaceChildren(
+      h(
+        "div",
+        { class: "table-wrap" },
+        h(
+          "table",
+          {},
+          h(
+            "thead",
+            {},
+            h(
+              "tr",
+              {},
+              ...["IP Address", "Hostname", "Last status", "Avg latency", "Last seen active", "Last checked", "Scans"].map((t) => h("th", {}, t))
+            )
+          ),
+          h(
+            "tbody",
+            {},
+            rows.map((asset) =>
+              h(
+                "tr",
+                {},
+                h("td", {}, asset.ip),
+                h("td", {}, asset.hostname || "—"),
+                h("td", {}, statusPill(asset.status)),
+                h("td", {}, fmtLatency(asset.avg_latency)),
+                h("td", {}, asset.last_seen || "never"),
+                h("td", {}, asset.last_checked || ""),
+                h("td", {}, String(asset.scan_count))
+              )
+            )
+          )
+        )
+      )
+    );
+  }
+
+  search.addEventListener("input", draw);
+  exportBtn.addEventListener("click", () => {
+    const rows = matching();
+    const header = "IP Address,Hostname,Last Status,Avg Latency,Last Seen Active,Last Checked,Scans";
+    const csv = [
+      header,
+      ...rows.map((asset) =>
+        [asset.ip, asset.hostname || "", asset.status, asset.avg_latency ?? "", asset.last_seen || "", asset.last_checked || "", asset.scan_count]
+          .map((value) => `"${String(value).replaceAll('"', '""')}"`)
+          .join(",")
+      ),
+    ].join("\n");
+    const link = document.createElement("a");
+    link.href = URL.createObjectURL(new Blob([csv], { type: "text/csv" }));
+    link.download = "ipmg_inventory.csv";
+    link.click();
+    URL.revokeObjectURL(link.href);
+  });
+
+  root.append(toolbar, tableHost);
+  draw();
+}

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,95 @@
+import threading
+
+import pytest
+
+from ipmg.core.engine import HostResult, ScanConfig, execute_scan
+
+
+def test_execute_scan_returns_result_per_host(monkeypatch):
+    def fake_ping_ip(ip, _timeout, _count):
+        return ("Active", 5.0) if ip == "8.8.8.8" else ("Inactive", None)
+
+    monkeypatch.setattr("ipmg.core.engine.ping_ip", fake_ping_ip)
+
+    results = execute_scan(["8.8.8.8", "1.1.1.1"], ScanConfig(threads=2))
+
+    by_ip = {result.ip: result for result in results}
+    assert by_ip["8.8.8.8"] == HostResult(ip="8.8.8.8", status="Active", latency=5.0)
+    assert by_ip["1.1.1.1"].status == "Inactive"
+
+
+def test_execute_scan_reports_progress_via_callback(monkeypatch):
+    monkeypatch.setattr("ipmg.core.engine.ping_ip", lambda *_a: ("Active", 1.0))
+
+    seen = []
+    execute_scan(
+        ["10.0.0.1", "10.0.0.2", "10.0.0.3"],
+        ScanConfig(threads=1),
+        on_result=lambda result, done, total: seen.append((result.ip, done, total)),
+    )
+
+    assert [done for _ip, done, _total in seen] == [1, 2, 3]
+    assert all(total == 3 for _ip, _done, total in seen)
+
+
+def test_execute_scan_converts_worker_errors(monkeypatch):
+    def fake_ping_ip(ip, _timeout, _count):
+        if ip == "10.0.0.2":
+            raise RuntimeError("boom")
+        return "Active", 1.0
+
+    monkeypatch.setattr("ipmg.core.engine.ping_ip", fake_ping_ip)
+
+    results = execute_scan(["10.0.0.1", "10.0.0.2"], ScanConfig(threads=2))
+
+    statuses = {result.ip: result.status for result in results}
+    assert statuses == {"10.0.0.1": "Active", "10.0.0.2": "Error"}
+
+
+def test_execute_scan_resolves_hostnames_when_enabled(monkeypatch):
+    monkeypatch.setattr("ipmg.core.engine.ping_ip", lambda *_a: ("Active", 1.0))
+    monkeypatch.setattr(
+        "ipmg.utils.helpers.socket.gethostbyaddr", lambda ip: (f"host-{ip}", [], [ip])
+    )
+
+    results = execute_scan(["10.0.0.1"], ScanConfig(resolve=True))
+
+    assert results[0].hostname == "host-10.0.0.1"
+
+
+def test_execute_scan_stops_early_when_requested(monkeypatch):
+    monkeypatch.setattr("ipmg.core.engine.ping_ip", lambda *_a: ("Active", 1.0))
+
+    stop = threading.Event()
+
+    def on_result(_result, done, _total):
+        if done == 2:
+            stop.set()
+
+    results = execute_scan(
+        [f"10.0.0.{n}" for n in range(1, 50)],
+        ScanConfig(threads=1),
+        on_result=on_result,
+        should_stop=stop.is_set,
+    )
+
+    assert len(results) < 49
+
+
+def test_scan_config_clamps_limits():
+    config = ScanConfig(timeout=999, count=999, threads=999, dns_cache_ttl=-5).clamped()
+
+    assert (config.timeout, config.count, config.threads) == (60, 10, 500)
+    assert config.dns_cache_ttl == 0
+
+
+def test_execute_scan_propagates_ping_errors(monkeypatch):
+    from ipmg.exceptions import PingError
+
+    def fake_ping_ip(*_a):
+        raise PingError("ping missing")
+
+    monkeypatch.setattr("ipmg.core.engine.ping_ip", fake_ping_ip)
+
+    with pytest.raises(PingError):
+        execute_scan(["10.0.0.1"], ScanConfig())

--- a/tests/test_file_io.py
+++ b/tests/test_file_io.py
@@ -6,9 +6,7 @@ from ipmg.infrastructure.file_io import load_targets, save_results
 
 def test_load_targets_from_csv(tmp_path):
     path = tmp_path / "targets.csv"
-    pd.DataFrame({"IP Address": ["8.8.8.8", "192.168.1.0/30", "8.8.8.8"]}).to_csv(
-        path, index=False
-    )
+    pd.DataFrame({"IP Address": ["8.8.8.8", "192.168.1.0/30", "8.8.8.8"]}).to_csv(path, index=False)
 
     assert load_targets(str(path)) == ["8.8.8.8", "192.168.1.1", "192.168.1.2"]
 
@@ -69,3 +67,40 @@ def test_save_results_writes_markdown_report(tmp_path, monkeypatch):
     assert "- Active rate: 50.00%" in report
     assert "| Active | 1 |" in report
     assert "| 8.8.8.8 | Active | 12.346 | dns.google |" in report
+
+
+def test_load_targets_from_literal_range():
+    assert load_targets("10.0.0.1-10.0.0.3") == ["10.0.0.1", "10.0.0.2", "10.0.0.3"]
+
+
+def test_load_targets_rejects_reversed_range():
+    with pytest.raises(Exception):
+        load_targets("10.0.0.9-10.0.0.1")
+
+
+def test_load_targets_skips_hostname_like_tokens_in_files(tmp_path):
+    path = tmp_path / "targets.txt"
+    path.write_text("8.8.4.4\nmy-host-name\n", encoding="utf-8")
+
+    assert load_targets(str(path)) == ["8.8.4.4"]
+
+
+def test_parse_manual_targets_mixed_input():
+    from ipmg.infrastructure.file_io import parse_manual_targets
+
+    parsed = parse_manual_targets("8.8.8.8\n# dns\n192.168.5.0/30, 10.0.0.1-10.0.0.2\n")
+
+    assert parsed == [
+        "8.8.8.8",
+        "192.168.5.1",
+        "192.168.5.2",
+        "10.0.0.1",
+        "10.0.0.2",
+    ]
+
+
+def test_parse_manual_targets_rejects_invalid_token():
+    from ipmg.infrastructure.file_io import parse_manual_targets
+
+    with pytest.raises(Exception):
+        parse_manual_targets("not-an-ip")

--- a/tests/test_scan_service.py
+++ b/tests/test_scan_service.py
@@ -23,7 +23,7 @@ def test_run_scan_handles_worker_errors(monkeypatch):
         captured["summary"] = (df.copy(), batch_timestamp, duration_seconds)
 
     monkeypatch.setattr("ipmg.services.scan_service.load_targets", fake_load_targets)
-    monkeypatch.setattr("ipmg.services.scan_service.ping_ip", fake_ping_ip)
+    monkeypatch.setattr("ipmg.core.engine.ping_ip", fake_ping_ip)
     monkeypatch.setattr("ipmg.services.scan_service.save_results", fake_save_results)
     monkeypatch.setattr("ipmg.services.scan_service.print_summary", fake_print_summary)
 
@@ -60,7 +60,7 @@ def test_run_scan_clamps_resource_limits(monkeypatch):
         return "Active", 1.0
 
     monkeypatch.setattr("ipmg.services.scan_service.load_targets", lambda _source: ["8.8.8.8"])
-    monkeypatch.setattr("ipmg.services.scan_service.ping_ip", fake_ping_ip)
+    monkeypatch.setattr("ipmg.core.engine.ping_ip", fake_ping_ip)
     monkeypatch.setattr("ipmg.services.scan_service.save_results", lambda *_args: None)
     monkeypatch.setattr("ipmg.services.scan_service.print_summary", lambda *_args: None)
 

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -1,0 +1,154 @@
+import json
+import time
+
+import pandas as pd
+import pytest
+from fastapi.testclient import TestClient
+
+from ipmg.web.app import create_app
+from ipmg.web.db import Database
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    monkeypatch.setattr("ipmg.core.engine.ping_ip", lambda ip, _t, _c: ("Active", 1.5))
+    app = create_app(Database(tmp_path / "api.db"))
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def wait_for_completion(client, scan_id, timeout=10.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        scan = client.get(f"/api/v1/scans/{scan_id}").json()
+        if scan["status"] != "running":
+            return scan
+        time.sleep(0.02)
+    raise AssertionError("scan did not finish in time")
+
+
+def test_create_scan_and_fetch_results(client):
+    response = client.post(
+        "/api/v1/scans",
+        json={"targets": "10.0.0.1\n10.0.0.2", "threads": 2, "source": "test"},
+    )
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["total"] == 2
+
+    scan = wait_for_completion(client, payload["id"])
+    assert scan["status"] == "complete"
+    assert scan["status_counts"] == {"Active": 2}
+
+    results = client.get(f"/api/v1/scans/{payload['id']}/results").json()
+    assert {row["ip"] for row in results} == {"10.0.0.1", "10.0.0.2"}
+
+
+def test_create_scan_rejects_invalid_targets(client):
+    response = client.post("/api/v1/scans", json={"targets": "not-an-ip"})
+    assert response.status_code == 400
+
+    response = client.post("/api/v1/scans", json={})
+    assert response.status_code == 400
+
+
+def test_scan_expands_cidr_and_ranges(client):
+    response = client.post(
+        "/api/v1/scans",
+        json={"targets": "192.168.0.0/30, 10.0.0.1-10.0.0.3", "threads": 4},
+    )
+    assert response.status_code == 201
+    assert response.json()["total"] == 5  # 2 CIDR hosts + 3 range hosts
+
+
+def test_report_downloads(client):
+    scan_id = client.post("/api/v1/scans", json={"targets": "10.0.0.1"}).json()["id"]
+    wait_for_completion(client, scan_id)
+
+    csv_response = client.get(f"/api/v1/scans/{scan_id}/report?fmt=csv")
+    assert csv_response.status_code == 200
+    assert "10.0.0.1" in csv_response.text
+    assert "attachment" in csv_response.headers["content-disposition"]
+
+    md_response = client.get(f"/api/v1/scans/{scan_id}/report?fmt=md")
+    assert "# IPMG Scan Report" in md_response.text
+
+    json_response = client.get(f"/api/v1/scans/{scan_id}/report?fmt=json")
+    assert json.loads(json_response.text)[0]["IP Address"] == "10.0.0.1"
+
+    xlsx_response = client.get(f"/api/v1/scans/{scan_id}/report?fmt=xlsx")
+    assert xlsx_response.status_code == 200
+    assert len(xlsx_response.content) > 0
+
+    assert client.get(f"/api/v1/scans/{scan_id}/report?fmt=pdf").status_code == 400
+
+
+def test_upload_csv_and_json(client, tmp_path):
+    csv_path = tmp_path / "targets.csv"
+    pd.DataFrame({"IP Address": ["8.8.8.8", "192.168.9.0/30"]}).to_csv(csv_path, index=False)
+
+    with open(csv_path, "rb") as handle:
+        response = client.post(
+            "/api/v1/upload", files={"file": ("targets.csv", handle, "text/csv")}
+        )
+    assert response.status_code == 200
+    assert response.json()["count"] == 3
+
+    response = client.post(
+        "/api/v1/upload",
+        files={"file": ("targets.json", json.dumps(["10.1.0.1", "10.1.0.2"]), "application/json")},
+    )
+    assert response.json()["targets"] == ["10.1.0.1", "10.1.0.2"]
+
+    response = client.post(
+        "/api/v1/upload",
+        files={
+            "file": ("targets.json", json.dumps([{"IP Address": "10.2.0.1"}]), "application/json")
+        },
+    )
+    assert response.json()["targets"] == ["10.2.0.1"]
+
+    response = client.post(
+        "/api/v1/upload", files={"file": ("bad.pdf", b"%PDF", "application/pdf")}
+    )
+    assert response.status_code == 400
+
+
+def test_stats_assets_and_delete(client):
+    scan_id = client.post("/api/v1/scans", json={"targets": "10.0.0.1"}).json()["id"]
+    wait_for_completion(client, scan_id)
+
+    stats = client.get("/api/v1/stats").json()
+    assert stats["scan_count"] == 1
+    assert stats["latest_scan"]["id"] == scan_id
+
+    assets = client.get("/api/v1/assets").json()
+    assert assets[0]["ip"] == "10.0.0.1"
+
+    assert client.delete(f"/api/v1/scans/{scan_id}").status_code == 204
+    assert client.get(f"/api/v1/scans/{scan_id}").status_code == 404
+    assert client.delete(f"/api/v1/scans/{scan_id}").status_code == 404
+
+
+def test_cancel_requires_running_scan(client):
+    scan_id = client.post("/api/v1/scans", json={"targets": "10.0.0.1"}).json()["id"]
+    wait_for_completion(client, scan_id)
+    assert client.post(f"/api/v1/scans/{scan_id}/cancel").status_code == 409
+
+
+def test_websocket_receives_scan_events(client):
+    with client.websocket_connect("/api/v1/ws") as websocket:
+        scan_id = client.post("/api/v1/scans", json={"targets": "10.0.0.1"}).json()["id"]
+
+        events = [websocket.receive_json() for _ in range(3)]
+        types = [event["type"] for event in events]
+        assert types == ["scan_started", "result", "scan_finished"]
+        assert all(event["scan_id"] == scan_id for event in events)
+        assert events[1]["result"]["ip"] == "10.0.0.1"
+        assert events[2]["status"] == "complete"
+
+
+def test_index_served(client):
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "IPMG Dashboard" in response.text

--- a/tests/test_web_db.py
+++ b/tests/test_web_db.py
@@ -1,0 +1,78 @@
+from ipmg.core.engine import HostResult
+from ipmg.web.db import Database
+
+
+def make_db(tmp_path):
+    return Database(tmp_path / "test.db")
+
+
+def test_scan_lifecycle(tmp_path):
+    db = make_db(tmp_path)
+
+    scan_id = db.create_scan("manual", 2, {"threads": 4})
+    db.add_result(scan_id, HostResult("10.0.0.1", "Active", 4.2, "router"))
+    db.add_result(scan_id, HostResult("10.0.0.2", "Timeout", None))
+    db.finish_scan(scan_id, "complete", 1.5)
+
+    scan = db.get_scan(scan_id)
+    assert scan["status"] == "complete"
+    assert scan["completed"] == 2
+    assert scan["config"] == {"threads": 4}
+    assert scan["status_counts"] == {"Active": 1, "Timeout": 1}
+    assert scan["avg_latency"] == 4.2
+    assert scan["duration_s"] == 1.5
+
+
+def test_results_filtering(tmp_path):
+    db = make_db(tmp_path)
+    scan_id = db.create_scan("manual", 3, {})
+    db.add_result(scan_id, HostResult("10.0.0.1", "Active", 1.0, "alpha"))
+    db.add_result(scan_id, HostResult("10.0.0.2", "Inactive", None, "beta"))
+    db.add_result(scan_id, HostResult("10.0.0.3", "Active", 2.0, "gamma"))
+
+    assert len(db.get_results(scan_id)) == 3
+    assert len(db.get_results(scan_id, status="Active")) == 2
+    assert [row["ip"] for row in db.get_results(scan_id, search="beta")] == ["10.0.0.2"]
+    assert [row["ip"] for row in db.get_results(scan_id, search="0.3")] == ["10.0.0.3"]
+
+
+def test_delete_scan_cascades(tmp_path):
+    db = make_db(tmp_path)
+    scan_id = db.create_scan("manual", 1, {})
+    db.add_result(scan_id, HostResult("10.0.0.1", "Active", 1.0))
+
+    assert db.delete_scan(scan_id) is True
+    assert db.get_scan(scan_id) is None
+    assert db.get_results(scan_id) == []
+    assert db.delete_scan(scan_id) is False
+
+
+def test_overview_and_inventory(tmp_path):
+    db = make_db(tmp_path)
+
+    first = db.create_scan("manual", 2, {})
+    db.add_result(first, HostResult("10.0.0.2", "Active", 3.0, "old-name"))
+    db.add_result(first, HostResult("10.0.0.10", "Inactive", None))
+    db.finish_scan(first, "complete", 1.0)
+
+    second = db.create_scan("manual", 2, {})
+    db.add_result(second, HostResult("10.0.0.2", "Inactive", None))
+    db.add_result(second, HostResult("10.0.0.10", "Active", 8.0, "new-name"))
+    db.finish_scan(second, "complete", 2.0)
+
+    overview = db.overview()
+    assert overview["scan_count"] == 2
+    assert overview["host_count"] == 2
+    assert overview["latest_scan"]["id"] == second
+    assert len(overview["trend"]) == 2
+    assert overview["running_scans"] == []
+
+    inventory = db.inventory()
+    # numeric IP ordering, not lexicographic
+    assert [row["ip"] for row in inventory] == ["10.0.0.2", "10.0.0.10"]
+    by_ip = {row["ip"]: row for row in inventory}
+    assert by_ip["10.0.0.2"]["status"] == "Inactive"
+    assert by_ip["10.0.0.2"]["hostname"] == "old-name"
+    assert by_ip["10.0.0.10"]["status"] == "Active"
+    assert by_ip["10.0.0.10"]["hostname"] == "new-name"
+    assert by_ip["10.0.0.10"]["scan_count"] == 2


### PR DESCRIPTION
## What changed

### Shared scan engine
- New `ipmg.core.engine.execute_scan()` used by **both** the CLI and the dashboard — no duplicated scanning logic. Supports per-result progress callbacks and cooperative cancellation.
- The existing CLI behaves exactly as before (same output, same flags).
- Target parsing now also accepts **IP ranges** (`10.0.0.1-10.0.0.200`) everywhere: CLI `--input`, files, and the dashboard.

### Backend (FastAPI + SQLite + WebSockets)
- REST API under `/api/v1`: create/list/get/cancel/delete scans, results with search + status filter, stats overview, host inventory, file upload, report downloads (XLSX/CSV/JSON/Markdown).
- Scan history persisted locally in SQLite (`~/.ipmg/dashboard.db`, override with `--db`).
- Live scan progress broadcast over a WebSocket (`/api/v1/ws`).
- Scans run in background threads — the UI never blocks.

### Frontend — fully local, no CDN
- Hand-written ES modules + CSS bundled inside the package; **zero external requests**, works completely offline.
- Pages: **Dashboard** (stat tiles, status donut, latency trend), **New Scan** (drag-drop upload of xlsx/csv/txt/list/json or manual IPs/CIDR/ranges + scan config), **Live Monitor** (WebSocket progress bar + live results), **History** (all scans, per-scan detail with search/filter/downloads/delete), **Inventory** (every host seen across scans, with CSV export).
- Light/dark theme (system-aware + manual toggle), responsive layout, CVD-validated status colors with labels everywhere.

### CLI integration
```
ipmg dashboard                # http://127.0.0.1:8080, opens browser
ipmg dashboard --port 9000 --no-browser
ipmg web                      # alias
```
Binds to 127.0.0.1 by default; `--host` opts into remote access.

## Acceptance criteria from #12
- [x] CLI continues to function without changes
- [x] Dashboard starts with `ipmg dashboard` (and `ipmg web`)
- [x] Browser launches automatically on localhost (`--no-browser` to disable)
- [x] Upload Excel, CSV, and JSON files (plus txt/list)
- [x] Manual IPs, ranges, and CIDR
- [x] Live scan progress via WebSockets
- [x] Reports downloadable from the browser (XLSX/CSV/JSON/MD)
- [x] Historical scan data stored locally (SQLite)
- [x] Dashboard and CLI share the same scanning engine
- [x] Cross-platform, no internet connection required, fully self-hosted

## Validation
- 43 tests pass (`pytest -q`): engine, range parsing, SQLite layer, REST API, WebSocket event ordering, report downloads, uploads
- End-to-end verified: launched `ipmg dashboard`, served all static assets, ran a real scan of `127.0.0.1-127.0.0.3` with hostname resolution via the API, downloaded MD/XLSX reports, checked stats + inventory
- `ruff`, `black`, and `bandit -r src` all clean; wheel build confirmed to include the static frontend

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)