### PR TITLE
fix: add websockets dependency for dashboard live updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dependencies = [
     "rich>=13.0",
     "fastapi>=0.110",
     "uvicorn>=0.27",
+    "websockets>=12",
     "python-multipart>=0.0.9",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ openpyxl>=3.1
 rich>=13.0
 fastapi>=0.110
 uvicorn>=0.27
+websockets>=12
 python-multipart>=0.0.9


### PR DESCRIPTION
## What changed
Added `websockets>=12` to the runtime dependencies (pyproject + requirements.txt).

## Why
Base `uvicorn` has no WebSocket protocol implementation — running `ipmg dashboard` from a clean `pip install ipmg` logged **"No supported WebSocket library detected. Unsupported upgrade request."** on every browser connection, so live scan progress never arrived. Tests didn't catch it because FastAPI's TestClient speaks ASGI directly, bypassing uvicorn's protocol layer.

## Validation
- Reproduced against a clean environment, then with the fix: launched `ipmg dashboard` and connected a real WebSocket client through uvicorn — received `scan_started` → `result` → `scan_finished` events for a live scan, no warnings in the server log
- All 43 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)